### PR TITLE
feat(helm): add existingSecret support for external secret references

### DIFF
--- a/helm-deployments/librecodeinterpreter/templates/_helpers.tpl
+++ b/helm-deployments/librecodeinterpreter/templates/_helpers.tpl
@@ -93,3 +93,28 @@ Redis URL
 {{- "redis://redis:6379/0" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Check if Helm-managed secret is needed
+Returns true if any of the following conditions are met:
+- api.existingSecret is not set (API_KEY will be auto-generated)
+- redis.existingSecret is not set (REDIS_URL needs to be generated)
+- minio.existingSecret is not set AND minio.useIAM is false (S3 credentials needed)
+*/}}
+{{- define "librecodeinterpreter.needsHelmSecret" -}}
+{{- if or (not .Values.api.existingSecret) (not .Values.redis.existingSecret) (and (not .Values.minio.existingSecret) (not .Values.minio.useIAM)) }}
+{{- true }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate MinIO/S3 configuration
+When not using existingSecret or IAM, accessKey and secretKey must be provided.
+*/}}
+{{- define "librecodeinterpreter.validateMinioConfig" -}}
+{{- if and (not .Values.minio.existingSecret) (not .Values.minio.useIAM) }}
+{{- if or (not .Values.minio.accessKey) (not .Values.minio.secretKey) }}
+{{- fail "minio.accessKey and minio.secretKey are required when not using existingSecret or IAM" -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-deployments/librecodeinterpreter/templates/deployment.yaml
+++ b/helm-deployments/librecodeinterpreter/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "librecodeinterpreter.validateMinioConfig" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,7 +15,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if not .Values.secretsStore.enabled }}
+        {{- if and (not .Values.secretsStore.enabled) (include "librecodeinterpreter.needsHelmSecret" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -74,9 +75,26 @@ spec:
             - secretRef:
                 name: {{ include "librecodeinterpreter.fullname" . }}-aws-secrets
             {{- else }}
+            {{- if include "librecodeinterpreter.needsHelmSecret" . }}
             # Use Helm-managed secrets
             - secretRef:
                 name: {{ include "librecodeinterpreter.fullname" . }}-secrets
+            {{- end }}
+            {{- if .Values.api.existingSecret }}
+            # External secret for API keys (API_KEY, MASTER_API_KEY)
+            - secretRef:
+                name: {{ .Values.api.existingSecret }}
+            {{- end }}
+            {{- if .Values.redis.existingSecret }}
+            # External secret for Redis (REDIS_URL)
+            - secretRef:
+                name: {{ .Values.redis.existingSecret }}
+            {{- end }}
+            {{- if .Values.minio.existingSecret }}
+            # External secret for S3/MinIO credentials (MINIO_ACCESS_KEY, MINIO_SECRET_KEY)
+            - secretRef:
+                name: {{ .Values.minio.existingSecret }}
+            {{- end }}
             {{- end }}
           volumeMounts:
             - name: data

--- a/helm-deployments/librecodeinterpreter/templates/secret.yaml
+++ b/helm-deployments/librecodeinterpreter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secretsStore.enabled }}
+{{- if and (not .Values.secretsStore.enabled) (include "librecodeinterpreter.needsHelmSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +8,7 @@ metadata:
     {{- include "librecodeinterpreter.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if not .Values.api.existingSecret }}
   # API Key - auto-generate if not provided
   {{- if .Values.api.apiKey }}
   API_KEY: {{ .Values.api.apiKey | quote }}
@@ -17,13 +18,18 @@ stringData:
   {{- if .Values.api.masterApiKey }}
   MASTER_API_KEY: {{ .Values.api.masterApiKey | quote }}
   {{- end }}
+  {{- end }}
+  {{- if not .Values.redis.existingSecret }}
   # Redis URL
   REDIS_URL: {{ include "librecodeinterpreter.redisUrl" . | quote }}
-  # MinIO Credentials
+  {{- end }}
+  {{- if and (not .Values.minio.existingSecret) (not .Values.minio.useIAM) }}
+  # S3-Compatible Storage Credentials (Garage/MinIO/S3)
   {{- if .Values.minio.accessKey }}
   MINIO_ACCESS_KEY: {{ .Values.minio.accessKey | quote }}
   {{- end }}
   {{- if .Values.minio.secretKey }}
   MINIO_SECRET_KEY: {{ .Values.minio.secretKey | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm-deployments/librecodeinterpreter/values.yaml
+++ b/helm-deployments/librecodeinterpreter/values.yaml
@@ -94,7 +94,11 @@ affinity: {}
 
 # External Dependencies
 redis:
-  # External Redis URL (required)
+  # Reference an existing Kubernetes Secret containing REDIS_URL
+  # When set, the url/host/port/password/db fields below are ignored
+  # Expected secret key: REDIS_URL (full connection string)
+  existingSecret: ""
+  # External Redis URL (required unless existingSecret is set)
   url: "redis://redis:6379/0"
   # Or specify individual fields
   host: ""
@@ -103,6 +107,10 @@ redis:
   db: 0
 
 minio:
+  # Reference an existing Kubernetes Secret containing S3 credentials
+  # When set, the accessKey/secretKey fields below are ignored
+  # Expected secret keys: MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+  existingSecret: ""
   endpoint: "minio:9000"
   accessKey: ""
   secretKey: ""
@@ -116,6 +124,10 @@ minio:
 
 # API Configuration
 api:
+  # Reference an existing Kubernetes Secret containing API keys
+  # When set, the apiKey/masterApiKey fields below are ignored
+  # Expected secret keys: API_KEY, and optionally MASTER_API_KEY
+  existingSecret: ""
   apiKey: "" # Will be auto-generated if empty
   masterApiKey: "" # For admin operations
   debug: false


### PR DESCRIPTION
## Description
Enable users to reference pre-existing Kubernetes secrets instead of having the chart manage secrets directly. This supports GitOps workflows and integration with External Secrets Operator, Vault, or manually- provisioned secrets.

Changes:
- Add existingSecret field to minio, api, and redis config sections
- Conditionally exclude values from Helm-managed secret when external secret is configured
- Add secretRef entries in envFrom for each configured existingSecret
- Add helper templates for secret management validation

Expected secret keys (documented in comments in values.yaml too):
- redis.existingSecret: REDIS_URL
- minio.existingSecret: MINIO_ACCESS_KEY, MINIO_SECRET_KEY
- api.existingSecret: API_KEY, optionally MASTER_API_KEY

### Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] `helm lint` and template rendering
- [x] Deployed in test cluster with external secrets

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
