### PR TITLE
feat: using kubecoderun as the project name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,11 +47,11 @@ MINIO_ENDPOINT=localhost:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 MINIO_SECURE=false
-MINIO_BUCKET=code-interpreter-files
+MINIO_BUCKET=kubecoderun-files
 MINIO_REGION=us-east-1
 
 # Docker Configuration
-DOCKER_IMAGE_REGISTRY=code-interpreter
+DOCKER_IMAGE_REGISTRY=kubecoderun
 # DOCKER_BASE_URL=unix://var/run/docker.sock
 DOCKER_TIMEOUT=60
 DOCKER_NETWORK_MODE=none
@@ -149,13 +149,13 @@ ENABLE_FILESYSTEM_ISOLATION=true
 # but are blocked from accessing host, other containers, and private networks
 # IMPORTANT: Requires NET_ADMIN capability for iptables management
 ENABLE_WAN_ACCESS=false
-WAN_NETWORK_NAME=code-interpreter-wan
+WAN_NETWORK_NAME=kubecoderun-wan
 # WAN_DNS_SERVERS=8.8.8.8,1.1.1.1,8.8.4.4
 
 # Logging Configuration
 LOG_LEVEL=INFO
 LOG_FORMAT=json
-# LOG_FILE=/var/log/code-interpreter-api.log
+# LOG_FILE=/var/log/kubecoderun-api.log
 LOG_MAX_SIZE_MB=100
 LOG_BACKUP_COUNT=5
 ENABLE_ACCESS_LOGS=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # Default owner for everything
-* @usnavy13
+* @aron-muon
 
 # Security-sensitive files require owner review
-/src/middleware/auth.py @usnavy13
-/src/middleware/security.py @usnavy13
-/src/services/auth.py @usnavy13
-/src/services/api_key_manager.py @usnavy13
-/src/config/security.py @usnavy13
-/docker/*.Dockerfile @usnavy13
+/src/middleware/auth.py @aron-muon
+/src/middleware/security.py @aron-muon
+/src/services/auth.py @aron-muon
+/src/services/api_key_manager.py @aron-muon
+/src/config/security.py @aron-muon
+/docker/*.Dockerfile @aron-muon
 
 # CI/CD changes require owner review
-/.github/workflows/ @usnavy13
+/.github/workflows/ @aron-muon
 
 # Documentation can be more open (remove this line to require review)
 # /docs/ 

--- a/.github/workflows/docker-build-reusable.yml
+++ b/.github/workflows/docker-build-reusable.yml
@@ -6,7 +6,7 @@ on:
       image_name:
         required: true
         type: string
-        description: 'Image name (e.g., librecodeinterpreter-sidecar)'
+        description: 'Image name (e.g., kubecoderun-sidecar)'
       dockerfile:
         required: true
         type: string

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,7 +115,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-api
+      image_name: kubecoderun-api
       dockerfile: Dockerfile
       context: .
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -129,7 +129,7 @@ jobs:
     if: needs.changes.outputs.sidecar == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-sidecar
+      image_name: kubecoderun-sidecar
       dockerfile: docker/sidecar/Dockerfile
       context: docker/sidecar
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -143,7 +143,7 @@ jobs:
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-python
+      image_name: kubecoderun-python
       dockerfile: docker/python.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -157,7 +157,7 @@ jobs:
     if: needs.changes.outputs.javascript == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-javascript
+      image_name: kubecoderun-javascript
       dockerfile: docker/nodejs.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -171,7 +171,7 @@ jobs:
     if: needs.changes.outputs.javascript == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-typescript
+      image_name: kubecoderun-typescript
       dockerfile: docker/nodejs.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -185,7 +185,7 @@ jobs:
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-go
+      image_name: kubecoderun-go
       dockerfile: docker/go.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -199,7 +199,7 @@ jobs:
     if: needs.changes.outputs.java == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-java
+      image_name: kubecoderun-java
       dockerfile: docker/java.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -213,7 +213,7 @@ jobs:
     if: needs.changes.outputs.c-cpp == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-c-cpp
+      image_name: kubecoderun-c-cpp
       dockerfile: docker/c-cpp.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -227,7 +227,7 @@ jobs:
     if: needs.changes.outputs.php == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-php
+      image_name: kubecoderun-php
       dockerfile: docker/php.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -241,7 +241,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-rust
+      image_name: kubecoderun-rust
       dockerfile: docker/rust.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -255,7 +255,7 @@ jobs:
     if: needs.changes.outputs.r == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-r
+      image_name: kubecoderun-r
       dockerfile: docker/r.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -269,7 +269,7 @@ jobs:
     if: needs.changes.outputs.fortran == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-fortran
+      image_name: kubecoderun-fortran
       dockerfile: docker/fortran.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -283,7 +283,7 @@ jobs:
     if: needs.changes.outputs.d == 'true' || needs.changes.outputs.force_all == 'true'
     uses: ./.github/workflows/docker-build-reusable.yml
     with:
-      image_name: librecodeinterpreter-d
+      image_name: kubecoderun-d
       dockerfile: docker/d.Dockerfile
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
@@ -304,7 +304,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-api
+      image_name: kubecoderun-api
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -320,7 +320,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-sidecar
+      image_name: kubecoderun-sidecar
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -336,7 +336,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-python
+      image_name: kubecoderun-python
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -352,7 +352,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-javascript
+      image_name: kubecoderun-javascript
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -368,7 +368,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-typescript
+      image_name: kubecoderun-typescript
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -384,7 +384,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-go
+      image_name: kubecoderun-go
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -400,7 +400,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-java
+      image_name: kubecoderun-java
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -416,7 +416,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-c-cpp
+      image_name: kubecoderun-c-cpp
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -432,7 +432,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-php
+      image_name: kubecoderun-php
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -448,7 +448,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-rust
+      image_name: kubecoderun-rust
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -464,7 +464,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-r
+      image_name: kubecoderun-r
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -480,7 +480,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-fortran
+      image_name: kubecoderun-fortran
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:
@@ -496,7 +496,7 @@ jobs:
       needs.changes.outputs.force_all != 'true'
     uses: ./.github/workflows/docker-retag-reusable.yml
     with:
-      image_name: librecodeinterpreter-d
+      image_name: kubecoderun-d
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
     secrets:

--- a/.github/workflows/docker-retag-reusable.yml
+++ b/.github/workflows/docker-retag-reusable.yml
@@ -6,7 +6,7 @@ on:
       image_name:
         required: true
         type: string
-        description: 'Image name (e.g., librecodeinterpreter-sidecar)'
+        description: 'Image name (e.g., kubecoderun-sidecar)'
       new_tag:
         required: true
         type: string

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Use version from Chart.yaml for manual runs
-            VERSION=$(grep '^version:' helm-deployments/librecodeinterpreter/Chart.yaml | awk '{print $2}')
+            VERSION=$(grep '^version:' helm-deployments/kubecoderun/Chart.yaml | awk '{print $2}')
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
           else
             # Use tag name (strip 'v' prefix if present)
@@ -34,16 +34,16 @@ jobs:
 
       - name: Update Chart.yaml version
         run: |
-          sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" helm-deployments/librecodeinterpreter/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" helm-deployments/librecodeinterpreter/Chart.yaml
-          cat helm-deployments/librecodeinterpreter/Chart.yaml
+          sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" helm-deployments/kubecoderun/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" helm-deployments/kubecoderun/Chart.yaml
+          cat helm-deployments/kubecoderun/Chart.yaml
 
       - name: Lint Helm chart
-        run: helm lint helm-deployments/librecodeinterpreter
+        run: helm lint helm-deployments/kubecoderun
 
       - name: Package Helm chart
         run: |
-          helm package helm-deployments/librecodeinterpreter --destination ./helm-package
+          helm package helm-deployments/kubecoderun --destination ./helm-package
           ls -la ./helm-package
 
       - name: Login to Artifactory OCI registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to LibreCodeInterpreter
+# Contributing to KubeCodeRun
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -18,17 +18,17 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [LibreCodeInterpreter Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
+This project and everyone participating in it is governed by the [KubeCodeRun Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
 
 ## I Have a Question
 
 > If you want to ask a question, we assume that you have read the available [Documentation](README.md).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/usnavy13/LibreCodeInterpreter/issues) that might help you. In case you've found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/aron-muon/KubeCodeRun/issues) that might help you. In case you've found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://github.com/usnavy13/LibreCodeInterpreter/issues/new).
+- Open an [Issue](https://github.com/aron-muon/KubeCodeRun/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (Python, Docker, Kubernetes, etc), depending on what seems relevant.
 
@@ -44,7 +44,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/usnavy13/LibreCodeInterpreter/issues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/aron-muon/KubeCodeRun/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -57,7 +57,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/usnavy13/LibreCodeInterpreter/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/aron-muon/KubeCodeRun/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -70,24 +70,24 @@ Once it's filed:
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for LibreCodeInterpreter, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+This section guides you through submitting an enhancement suggestion for KubeCodeRun, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
 - Read the [documentation](README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://github.com/usnavy13/LibreCodeInterpreter/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/aron-muon/KubeCodeRun/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 #### How to Submit a Good Enhancement Suggestion
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/usnavy13/LibreCodeInterpreter/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/aron-muon/KubeCodeRun/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as much detail as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives you do not like.
 - You may want to include **screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to.
-- **Explain why this enhancement would be useful** to most LibreCodeInterpreter users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- **Explain why this enhancement would be useful** to most KubeCodeRun users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 ### Your First Code Contribution
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ARG VERSION=1.1.1
 ARG VCS_REF
 
 # Add metadata
-LABEL maintainer="LibreCodeInterpreter Contributors" \
-    org.opencontainers.image.title="LibreCodeInterpreter" \
+LABEL maintainer="KubeCodeRun Contributors" \
+    org.opencontainers.image.title="KubeCodeRun" \
     org.opencontainers.image.description="Secure API for executing code in isolated environments" \
     org.opencontainers.image.version="${VERSION}" \
     org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.revision="${VCS_REF}" \
-    org.opencontainers.image.source="https://github.com/LibreCodeInterpreter/LibreCodeInterpreter" \
+    org.opencontainers.image.source="https://github.com/KubeCodeRun/KubeCodeRun" \
     org.opencontainers.image.licenses="Apache-2.0"
 
 # Install system dependencies for building

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024 LibreCodeInterpreter Contributors
+   Copyright 2024 KubeCodeRun Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# LibreCodeInterpreter
+# KubeCodeRun
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![CI Status](https://github.com/usnavy13/LibreCodeInterpreter/actions/workflows/lint.yml/badge.svg)](https://github.com/usnavy13/LibreCodeInterpreter/actions/workflows/lint.yml)
+[![CI Status](https://github.com/aron-muon/KubeCodeRun/actions/workflows/lint.yml/badge.svg)](https://github.com/aron-muon/KubeCodeRun/actions/workflows/lint.yml)
 
 A secure, open-source code interpreter API that provides sandboxed code execution in isolated Kubernetes pods. Compatible with LibreChat's Code Interpreter API.
 
@@ -21,15 +21,15 @@ Get up and running in minutes with Kubernetes deployment.
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/usnavy13/LibreCodeInterpreter.git
-   cd LibreCodeInterpreter
+   git clone https://github.com/aron-muon/KubeCodeRun.git
+   cd KubeCodeRun
    ```
 
 2. **Deploy with Helm**
 
    ```bash
-   helm install librecodeinterpreter ./helm-deployments/librecodeinterpreter \
-     --namespace librecodeinterpreter \
+   helm install kubecoderun ./helm-deployments/kubecoderun \
+     --namespace kubecoderun \
      --create-namespace \
      --set replicaCount=2 \
      --set execution.languages.python.poolSize=5
@@ -39,7 +39,7 @@ Get up and running in minutes with Kubernetes deployment.
 
    ```bash
    # Port-forward for local access
-   kubectl -n librecodeinterpreter port-forward svc/librecodeinterpreter 8000:8000
+   kubectl -n kubecoderun port-forward svc/kubecoderun 8000:8000
    ```
 
 The API will be available at `http://localhost:8000`.
@@ -88,7 +88,7 @@ The dashboard requires the master API key for authentication.
 
 ## Architecture
 
-The LibreCodeInterpreter is built with a focus on security, speed, and scalability. It uses a **Kubernetes-native architecture** with **FastAPI** for the web layer, **warm pod pools** for low-latency execution, and **Redis** for session management.
+The KubeCodeRun is built with a focus on security, speed, and scalability. It uses a **Kubernetes-native architecture** with **FastAPI** for the web layer, **warm pod pools** for low-latency execution, and **Redis** for session management.
 
 Key features include:
 
@@ -161,6 +161,10 @@ Please see [SECURITY.md](docs/SECURITY.md) for our security policy and reporting
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started, our code of conduct, and the pull request process.
+
+## Acknowledgments
+
+This project was originally a fork of [@usnavy13](https://github.com/usnavy13)'s [LibreCodeInterpreter](https://github.com/usnavy13/LibreCodeInterpreter). Their work was foundational in developing the HTTP approach to running code execution.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 ## Reporting a Vulnerability
 
-We take the security of LibreCodeInterpreter seriously. If you believe you have found a security vulnerability, please report it to us as described below.
+We take the security of KubeCodeRun seriously. If you believe you have found a security vulnerability, please report it to us as described below.
 
 ### Disclosure Policy
 
@@ -17,7 +17,7 @@ In the interest of protecting our users, we ask that you do not share informatio
 
 ### How to Report
 
-To report a vulnerability, please email aron@muonspace.com or open a **Security Advisory** at https://github.com/usnavy13/LibreCodeInterpreter/security/advisories/new.
+To report a vulnerability, please email aron@muonspace.com or open a **Security Advisory** at https://github.com/aron-muon/KubeCodeRun/security/advisories/new.
 
 Please include:
 
@@ -30,4 +30,4 @@ Please include:
 
 We will acknowledge receipt of your report within 48 hours and will strive to provide you with an update on our analysis and planned resolution within 1 week.
 
-Thank you for helping keep LibreCodeInterpreter secure!
+Thank you for helping keep KubeCodeRun secure!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   # Redis for session management and state persistence
   redis:
     image: redis:7-alpine
-    container_name: code-interpreter-redis
+    container_name: kubecoderun-redis
     ports:
       - "127.0.0.1:6379:6379"
     environment:
@@ -36,7 +36,7 @@ services:
   # MinIO for file storage
   minio:
     image: minio/minio:latest
-    container_name: code-interpreter-minio
+    container_name: kubecoderun-minio
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001"
@@ -57,14 +57,14 @@ services:
   # MinIO bucket initialization
   minio-init:
     image: minio/mc:latest
-    container_name: code-interpreter-minio-init
+    container_name: kubecoderun-minio-init
     depends_on:
       - minio
     environment:
       - MINIO_ENDPOINT=minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
-      - MINIO_BUCKET=${MINIO_BUCKET:-code-interpreter-files}
+      - MINIO_BUCKET=${MINIO_BUCKET:-kubecoderun-files}
     entrypoint: >
       /bin/sh -c "
         echo 'Waiting for MinIO to be ready...';

--- a/docker/sidecar/main.py
+++ b/docker/sidecar/main.py
@@ -76,7 +76,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="LibreCodeInterpreter Sidecar",
+    title="KubeCodeRun Sidecar",
     description="HTTP API for code execution in Kubernetes pods",
     version="1.1.1",
     lifespan=lifespan,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,14 +1,14 @@
-# LibreCodeInterpreter Architecture
+# KubeCodeRun Architecture
 
 ## Overview
 
-LibreCodeInterpreter is a secure API for executing code in isolated Kubernetes pods. It uses a **Kubernetes-native architecture** with warm pod pools for low-latency execution and Jobs for cold-path languages.
+KubeCodeRun is a secure API for executing code in isolated Kubernetes pods. It uses a **Kubernetes-native architecture** with warm pod pools for low-latency execution and Jobs for cold-path languages.
 
 ## High-Level Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                         LibreCodeInterpreter API                             │
+│                         KubeCodeRun API                             │
 │                         (FastAPI Application)                                │
 └─────────────────────────────────────────────────────────────────────────────┘
                                     │
@@ -252,9 +252,9 @@ POD_POOL_EXHAUSTION_TRIGGER=true   # Trigger immediate replenishment when exhaus
 ### Kubernetes Settings
 
 ```python
-K8S_NAMESPACE=librecodeinterpreter
-K8S_SIDECAR_IMAGE=aronmuon/librecodeinterpreter-sidecar:latest
-K8S_IMAGE_REGISTRY=aronmuon/librecodeinterpreter
+K8S_NAMESPACE=kubecoderun
+K8S_SIDECAR_IMAGE=aronmuon/kubecoderun-sidecar:latest
+K8S_IMAGE_REGISTRY=aronmuon/kubecoderun
 K8S_IMAGE_TAG=latest
 K8S_CPU_LIMIT=1
 K8S_MEMORY_LIMIT=512Mi
@@ -341,7 +341,7 @@ docker/
     └── requirements.txt
 
 helm-deployments/
-└── librecodeinterpreter/  # Helm chart
+└── kubecoderun/  # Helm chart
     ├── templates/
     │   ├── deployment.yaml
     │   ├── service.yaml
@@ -378,8 +378,8 @@ The API exposes metrics for:
 ### Helm Installation
 
 ```bash
-helm install librecodeinterpreter ./helm-deployments/librecodeinterpreter \
-  --namespace librecodeinterpreter \
+helm install kubecoderun ./helm-deployments/kubecoderun \
+  --namespace kubecoderun \
   --create-namespace \
   --set replicaCount=2 \
   --set execution.languages.python.poolSize=5

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -164,7 +164,7 @@ MinIO provides S3-compatible object storage for files.
 | `MINIO_ACCESS_KEY` | (required)               | MinIO access key (required when not using IAM) |
 | `MINIO_SECRET_KEY` | (required)               | MinIO secret key (required when not using IAM) |
 | `MINIO_SECURE`     | `false`                  | Use HTTPS for MinIO connections             |
-| `MINIO_BUCKET`     | `code-interpreter-files` | Bucket name for file storage                |
+| `MINIO_BUCKET`     | `kubecoderun-files` | Bucket name for file storage                |
 | `MINIO_REGION`     | `us-east-1`              | MinIO region                                |
 | `MINIO_USE_IAM`    | `false`                  | Use IAM credentials instead of keys         |
 
@@ -175,8 +175,8 @@ Kubernetes is used for secure code execution in isolated pods.
 | Variable               | Default                                      | Description                              |
 | ---------------------- | -------------------------------------------- | ---------------------------------------- |
 | `K8S_NAMESPACE`        | `""` (uses API's namespace)                  | Namespace for execution pods             |
-| `K8S_SIDECAR_IMAGE`    | `aronmuon/librecodeinterpreter-sidecar:latest` | HTTP sidecar image for pod communication |
-| `K8S_IMAGE_REGISTRY`   | `aronmuon/librecodeinterpreter`              | Registry prefix for language images      |
+| `K8S_SIDECAR_IMAGE`    | `aronmuon/kubecoderun-sidecar:latest` | HTTP sidecar image for pod communication |
+| `K8S_IMAGE_REGISTRY`   | `aronmuon/kubecoderun`              | Registry prefix for language images      |
 | `K8S_IMAGE_TAG`        | `latest`                                     | Image tag for language images            |
 | `K8S_CPU_LIMIT`        | `1`                                          | CPU limit per execution pod              |
 | `K8S_MEMORY_LIMIT`     | `512Mi`                                      | Memory limit per execution pod           |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,8 +17,8 @@ This document provides detailed instructions for setting up the development envi
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/usnavy13/LibreCodeInterpreter.git
-   cd LibreCodeInterpreter
+   git clone https://github.com/aron-muon/KubeCodeRun.git
+   cd KubeCodeRun
    ```
 
 2. **Create a virtual environment**
@@ -75,19 +75,19 @@ The API requires language-specific execution images and the HTTP sidecar image.
 
 ```bash
 # Build individual language images (from project root)
-docker build -f docker/python.Dockerfile -t librecodeinterpreter/python:latest .
-docker build -f docker/nodejs.Dockerfile -t librecodeinterpreter/nodejs:latest .
-docker build -f docker/go.Dockerfile -t librecodeinterpreter/go:latest .
-docker build -f docker/java.Dockerfile -t librecodeinterpreter/java:latest .
-docker build -f docker/rust.Dockerfile -t librecodeinterpreter/rust:latest .
-docker build -f docker/php.Dockerfile -t librecodeinterpreter/php:latest .
-docker build -f docker/c-cpp.Dockerfile -t librecodeinterpreter/c-cpp:latest .
-docker build -f docker/r.Dockerfile -t librecodeinterpreter/r:latest .
-docker build -f docker/fortran.Dockerfile -t librecodeinterpreter/fortran:latest .
-docker build -f docker/d.Dockerfile -t librecodeinterpreter/d:latest .
+docker build -f docker/python.Dockerfile -t kubecoderun/python:latest .
+docker build -f docker/nodejs.Dockerfile -t kubecoderun/nodejs:latest .
+docker build -f docker/go.Dockerfile -t kubecoderun/go:latest .
+docker build -f docker/java.Dockerfile -t kubecoderun/java:latest .
+docker build -f docker/rust.Dockerfile -t kubecoderun/rust:latest .
+docker build -f docker/php.Dockerfile -t kubecoderun/php:latest .
+docker build -f docker/c-cpp.Dockerfile -t kubecoderun/c-cpp:latest .
+docker build -f docker/r.Dockerfile -t kubecoderun/r:latest .
+docker build -f docker/fortran.Dockerfile -t kubecoderun/fortran:latest .
+docker build -f docker/d.Dockerfile -t kubecoderun/d:latest .
 
 # Build the HTTP sidecar image
-docker build -t librecodeinterpreter/sidecar:latest docker/sidecar/
+docker build -t kubecoderun/sidecar:latest docker/sidecar/
 ```
 
 For more details on Kubernetes pod management, see [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -321,7 +321,7 @@ Recommended alert conditions:
 
 3. **Check pod health**:
    ```bash
-   kubectl -n librecodeinterpreter get pods -l app.kubernetes.io/managed-by=librecodeinterpreter
+   kubectl -n kubecoderun get pods -l app.kubernetes.io/managed-by=kubecoderun
    ```
    If pods are unhealthy, check logs with `kubectl logs`.
 
@@ -344,7 +344,7 @@ Recommended alert conditions:
 3. **Check pod cleanup**:
    Pods should be destroyed immediately. Check for orphaned pods:
    ```bash
-   kubectl -n librecodeinterpreter get pods -l app.kubernetes.io/managed-by=librecodeinterpreter
+   kubectl -n kubecoderun get pods -l app.kubernetes.io/managed-by=kubecoderun
    ```
 
 ### Memory Issues
@@ -352,7 +352,7 @@ Recommended alert conditions:
 1. **Check pod memory**:
 
    ```bash
-   kubectl top pods -n librecodeinterpreter
+   kubectl top pods -n kubecoderun
    ```
 
 2. **Reduce state size limit**:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -377,7 +377,7 @@ pytest --cov=src --cov-report=xml tests/
 1. **Check infrastructure:**
 
    ```bash
-   kubectl get pods -n librecodeinterpreter  # All pods should be "Running"
+   kubectl get pods -n kubecoderun  # All pods should be "Running"
    ```
 
 2. **Check API health:**
@@ -388,7 +388,7 @@ pytest --cov=src --cov-report=xml tests/
 
 3. **Check logs:**
    ```bash
-   kubectl logs -n librecodeinterpreter deployment/librecodeinterpreter
+   kubectl logs -n kubecoderun deployment/kubecoderun
    ```
 
 ### Async Test Issues

--- a/helm-deployments/kubecoderun/Chart.yaml
+++ b/helm-deployments/kubecoderun/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-name: librecodeinterpreter
-description: LibreCodeInterpreter - Kubernetes-native code execution service
+name: kubecoderun
+description: KubeCodeRun - Kubernetes-native code execution service
 type: application
 version: 1.1.1
 appVersion: "1.1.1"
 keywords:
-  - code-interpreter
+  - kubecoderun
   - code-execution
   - kubernetes
   - python

--- a/helm-deployments/kubecoderun/templates/_helpers.tpl
+++ b/helm-deployments/kubecoderun/templates/_helpers.tpl
@@ -1,14 +1,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "librecodeinterpreter.name" -}}
+{{- define "kubecoderun.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 */}}
-{{- define "librecodeinterpreter.fullname" -}}
+{{- define "kubecoderun.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -24,16 +24,16 @@ Create a default fully qualified app name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "librecodeinterpreter.chart" -}}
+{{- define "kubecoderun.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "librecodeinterpreter.labels" -}}
-helm.sh/chart: {{ include "librecodeinterpreter.chart" . }}
-{{ include "librecodeinterpreter.selectorLabels" . }}
+{{- define "kubecoderun.labels" -}}
+helm.sh/chart: {{ include "kubecoderun.chart" . }}
+{{ include "kubecoderun.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -43,17 +43,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "librecodeinterpreter.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "librecodeinterpreter.name" . }}
+{{- define "kubecoderun.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubecoderun.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use for API
 */}}
-{{- define "librecodeinterpreter.serviceAccountName" -}}
+{{- define "kubecoderun.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "librecodeinterpreter.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "kubecoderun.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -62,9 +62,9 @@ Create the name of the service account to use for API
 {{/*
 Create the name of the executor service account
 */}}
-{{- define "librecodeinterpreter.executorServiceAccountName" -}}
+{{- define "kubecoderun.executorServiceAccountName" -}}
 {{- if .Values.execution.serviceAccount.create }}
-{{- default (printf "%s-executor" (include "librecodeinterpreter.fullname" .)) .Values.execution.serviceAccount.name }}
+{{- default (printf "%s-executor" (include "kubecoderun.fullname" .)) .Values.execution.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.execution.serviceAccount.name }}
 {{- end }}
@@ -73,14 +73,14 @@ Create the name of the executor service account
 {{/*
 Execution namespace
 */}}
-{{- define "librecodeinterpreter.executionNamespace" -}}
+{{- define "kubecoderun.executionNamespace" -}}
 {{- default .Release.Namespace .Values.execution.namespace }}
 {{- end }}
 
 {{/*
 Redis URL
 */}}
-{{- define "librecodeinterpreter.redisUrl" -}}
+{{- define "kubecoderun.redisUrl" -}}
 {{- if .Values.redis.url }}
 {{- .Values.redis.url }}
 {{- else if .Values.redis.host }}
@@ -101,7 +101,7 @@ Returns true if any of the following conditions are met:
 - redis.existingSecret is not set (REDIS_URL needs to be generated)
 - minio.existingSecret is not set AND minio.useIAM is false (S3 credentials needed)
 */}}
-{{- define "librecodeinterpreter.needsHelmSecret" -}}
+{{- define "kubecoderun.needsHelmSecret" -}}
 {{- if or (not .Values.api.existingSecret) (not .Values.redis.existingSecret) (and (not .Values.minio.existingSecret) (not .Values.minio.useIAM)) }}
 {{- true }}
 {{- end }}
@@ -111,7 +111,7 @@ Returns true if any of the following conditions are met:
 Validate MinIO/S3 configuration
 When not using existingSecret or IAM, accessKey and secretKey must be provided.
 */}}
-{{- define "librecodeinterpreter.validateMinioConfig" -}}
+{{- define "kubecoderun.validateMinioConfig" -}}
 {{- if and (not .Values.minio.existingSecret) (not .Values.minio.useIAM) }}
 {{- if or (not .Values.minio.accessKey) (not .Values.minio.secretKey) }}
 {{- fail "minio.accessKey and minio.secretKey are required when not using existingSecret or IAM" -}}

--- a/helm-deployments/kubecoderun/templates/cleanup-job.yaml
+++ b/helm-deployments/kubecoderun/templates/cleanup-job.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-cleanup
+  name: {{ include "kubecoderun.fullname" . }}-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
@@ -14,7 +14,7 @@ spec:
   ttlSecondsAfterFinished: 60
   template:
     spec:
-      serviceAccountName: {{ include "librecodeinterpreter.serviceAccountName" . }}
+      serviceAccountName: {{ include "kubecoderun.serviceAccountName" . }}
       restartPolicy: Never
       containers:
         - name: cleanup
@@ -25,12 +25,12 @@ spec:
             - |
               echo "Cleaning up pool pods..."
               kubectl delete pods -n {{ .Release.Namespace }} \
-                -l app.kubernetes.io/managed-by=librecodeinterpreter \
-                -l librecodeinterpreter.io/type=pool \
+                -l app.kubernetes.io/managed-by=kubecoderun \
+                -l kubecoderun.io/type=pool \
                 --ignore-not-found=true
               echo "Cleaning up any remaining jobs..."
               kubectl delete jobs -n {{ .Release.Namespace }} \
-                -l app.kubernetes.io/managed-by=librecodeinterpreter \
+                -l app.kubernetes.io/managed-by=kubecoderun \
                 --ignore-not-found=true
               echo "Cleanup complete."
 {{- end }}

--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-config
+  name: {{ include "kubecoderun.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
 data:
   # API Configuration
   API_HOST: "0.0.0.0"
@@ -14,8 +14,8 @@ data:
   LOG_FORMAT: {{ .Values.api.logFormat | quote }}
 
   # Kubernetes Configuration
-  K8S_NAMESPACE: {{ include "librecodeinterpreter.executionNamespace" . | quote }}
-  K8S_SERVICE_ACCOUNT: {{ include "librecodeinterpreter.executorServiceAccountName" . | quote }}
+  K8S_NAMESPACE: {{ include "kubecoderun.executionNamespace" . | quote }}
+  K8S_SERVICE_ACCOUNT: {{ include "kubecoderun.executorServiceAccountName" . | quote }}
   K8S_SIDECAR_IMAGE: {{ .Values.execution.sidecar.image | quote }}
   K8S_SIDECAR_PORT: {{ .Values.execution.sidecar.port | quote }}
   K8S_IMAGE_REGISTRY: {{ .Values.execution.imageRegistry | quote }}

--- a/helm-deployments/kubecoderun/templates/deployment.yaml
+++ b/helm-deployments/kubecoderun/templates/deployment.yaml
@@ -1,34 +1,34 @@
-{{- include "librecodeinterpreter.validateMinioConfig" . -}}
+{{- include "kubecoderun.validateMinioConfig" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}
+  name: {{ include "kubecoderun.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "librecodeinterpreter.selectorLabels" . | nindent 6 }}
+      {{- include "kubecoderun.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if and (not .Values.secretsStore.enabled) (include "librecodeinterpreter.needsHelmSecret" .) }}
+        {{- if and (not .Values.secretsStore.enabled) (include "kubecoderun.needsHelmSecret" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "librecodeinterpreter.selectorLabels" . | nindent 8 }}
+        {{- include "kubecoderun.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "librecodeinterpreter.serviceAccountName" . }}
+      serviceAccountName: {{ include "kubecoderun.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -69,16 +69,16 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
             - configMapRef:
-                name: {{ include "librecodeinterpreter.fullname" . }}-config
+                name: {{ include "kubecoderun.fullname" . }}-config
             {{- if .Values.secretsStore.enabled }}
             # Use secrets synced from AWS Secrets Manager via CSI driver
             - secretRef:
-                name: {{ include "librecodeinterpreter.fullname" . }}-aws-secrets
+                name: {{ include "kubecoderun.fullname" . }}-aws-secrets
             {{- else }}
-            {{- if include "librecodeinterpreter.needsHelmSecret" . }}
+            {{- if include "kubecoderun.needsHelmSecret" . }}
             # Use Helm-managed secrets
             - secretRef:
-                name: {{ include "librecodeinterpreter.fullname" . }}-secrets
+                name: {{ include "kubecoderun.fullname" . }}-secrets
             {{- end }}
             {{- if .Values.api.existingSecret }}
             # External secret for API keys (API_KEY, MASTER_API_KEY)
@@ -115,7 +115,7 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: {{ include "librecodeinterpreter.fullname" . }}-secrets
+              secretProviderClass: {{ include "kubecoderun.fullname" . }}-secrets
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-deployments/kubecoderun/templates/executor-serviceaccount.yaml
+++ b/helm-deployments/kubecoderun/templates/executor-serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "librecodeinterpreter.executorServiceAccountName" . }}
-  namespace: {{ include "librecodeinterpreter.executionNamespace" . }}
+  name: {{ include "kubecoderun.executorServiceAccountName" . }}
+  namespace: {{ include "kubecoderun.executionNamespace" . }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
     app.kubernetes.io/component: executor
   {{- with .Values.execution.serviceAccount.annotations }}
   annotations:

--- a/helm-deployments/kubecoderun/templates/ingress.yaml
+++ b/helm-deployments/kubecoderun/templates/ingress.yaml
@@ -2,10 +2,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}
+  name: {{ include "kubecoderun.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -34,7 +34,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "librecodeinterpreter.fullname" $ }}
+                name: {{ include "kubecoderun.fullname" $ }}
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}

--- a/helm-deployments/kubecoderun/templates/networkpolicy.yaml
+++ b/helm-deployments/kubecoderun/templates/networkpolicy.yaml
@@ -2,16 +2,16 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-execution-isolation
-  namespace: {{ include "librecodeinterpreter.executionNamespace" . }}
+  name: {{ include "kubecoderun.fullname" . }}-execution-isolation
+  namespace: {{ include "kubecoderun.executionNamespace" . }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
     app.kubernetes.io/component: network-policy
 spec:
-  # Apply to all execution pods (managed by librecodeinterpreter)
+  # Apply to all execution pods (managed by kubecoderun)
   podSelector:
     matchLabels:
-      app.kubernetes.io/managed-by: librecodeinterpreter
+      app.kubernetes.io/managed-by: kubecoderun
   policyTypes:
     - Ingress
     - Egress
@@ -20,7 +20,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              {{- include "librecodeinterpreter.selectorLabels" . | nindent 14 }}
+              {{- include "kubecoderun.selectorLabels" . | nindent 14 }}
       ports:
         - protocol: TCP
           port: {{ .Values.execution.sidecar.port }}

--- a/helm-deployments/kubecoderun/templates/role.yaml
+++ b/helm-deployments/kubecoderun/templates/role.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-executor
-  namespace: {{ include "librecodeinterpreter.executionNamespace" . }}
+  name: {{ include "kubecoderun.fullname" . }}-executor
+  namespace: {{ include "kubecoderun.executionNamespace" . }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
     app.kubernetes.io/component: executor
 rules:
   # Pod management for warm pools

--- a/helm-deployments/kubecoderun/templates/rolebinding.yaml
+++ b/helm-deployments/kubecoderun/templates/rolebinding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-executor
-  namespace: {{ include "librecodeinterpreter.executionNamespace" . }}
+  name: {{ include "kubecoderun.fullname" . }}-executor
+  namespace: {{ include "kubecoderun.executionNamespace" . }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
     app.kubernetes.io/component: executor
 subjects:
   # Bind to the API service account (the API pod creates execution pods)
   - kind: ServiceAccount
-    name: {{ include "librecodeinterpreter.serviceAccountName" . }}
+    name: {{ include "kubecoderun.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "librecodeinterpreter.fullname" . }}-executor
+  name: {{ include "kubecoderun.fullname" . }}-executor
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-deployments/kubecoderun/templates/secret.yaml
+++ b/helm-deployments/kubecoderun/templates/secret.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.secretsStore.enabled) (include "librecodeinterpreter.needsHelmSecret" .) }}
+{{- if and (not .Values.secretsStore.enabled) (include "kubecoderun.needsHelmSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-secrets
+  name: {{ include "kubecoderun.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- if not .Values.api.existingSecret }}
@@ -21,7 +21,7 @@ stringData:
   {{- end }}
   {{- if not .Values.redis.existingSecret }}
   # Redis URL
-  REDIS_URL: {{ include "librecodeinterpreter.redisUrl" . | quote }}
+  REDIS_URL: {{ include "kubecoderun.redisUrl" . | quote }}
   {{- end }}
   {{- if and (not .Values.minio.existingSecret) (not .Values.minio.useIAM) }}
   # S3-Compatible Storage Credentials (Garage/MinIO/S3)

--- a/helm-deployments/kubecoderun/templates/secretproviderclass.yaml
+++ b/helm-deployments/kubecoderun/templates/secretproviderclass.yaml
@@ -2,10 +2,10 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}-secrets
+  name: {{ include "kubecoderun.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
 spec:
   provider: {{ .Values.secretsStore.provider }}
   parameters:
@@ -28,7 +28,7 @@ spec:
     {{- end }}
   {{- if .Values.secretsStore.secretObjects }}
   secretObjects:
-    - secretName: {{ include "librecodeinterpreter.fullname" . }}-aws-secrets
+    - secretName: {{ include "kubecoderun.fullname" . }}-aws-secrets
       type: Opaque
       data:
         {{- range .Values.secretsStore.secretObjects }}

--- a/helm-deployments/kubecoderun/templates/service.yaml
+++ b/helm-deployments/kubecoderun/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "librecodeinterpreter.fullname" . }}
+  name: {{ include "kubecoderun.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "librecodeinterpreter.selectorLabels" . | nindent 4 }}
+    {{- include "kubecoderun.selectorLabels" . | nindent 4 }}

--- a/helm-deployments/kubecoderun/templates/serviceaccount.yaml
+++ b/helm-deployments/kubecoderun/templates/serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "librecodeinterpreter.serviceAccountName" . }}
+  name: {{ include "kubecoderun.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "librecodeinterpreter.labels" . | nindent 4 }}
+    {{- include "kubecoderun.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -1,10 +1,10 @@
-# LibreCodeInterpreter Helm Chart Values
+# KubeCodeRun Helm Chart Values
 
 # API Deployment Configuration
 replicaCount: 1
 
 image:
-  repository: aronmuon/librecodeinterpreter-api
+  repository: aronmuon/kubecoderun-api
   pullPolicy: IfNotPresent
   tag: "latest"
 
@@ -39,7 +39,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: librecodeinterpreter.local
+    - host: kubecoderun.local
       paths:
         - path: /
           pathType: Prefix
@@ -115,7 +115,7 @@ minio:
   accessKey: ""
   secretKey: ""
   secure: false
-  bucket: "code-interpreter-files"
+  bucket: "kubecoderun-files"
   # Use IAM role for authentication (IRSA on EKS)
   # When true, accessKey and secretKey are not required
   useIAM: false
@@ -145,8 +145,8 @@ execution:
 
   # Image registry configuration
   # Images are named: {imageRegistry}-{language}:{imageTag}
-  # e.g., aronmuon/librecodeinterpreter-python:latest
-  imageRegistry: "aronmuon/librecodeinterpreter"
+  # e.g., aronmuon/kubecoderun-python:latest
+  imageRegistry: "aronmuon/kubecoderun"
   imageTag: "latest"
   # Image pull policy for execution pods (IfNotPresent, Always, Never)
   # Use "Always" when using :latest tags to ensure fresh images
@@ -155,12 +155,12 @@ execution:
   # Service account for execution pods (with pod/job create permissions)
   serviceAccount:
     create: true
-    name: "librecodeinterpreter-executor"
+    name: "kubecoderun-executor"
     annotations: {}
 
   # Sidecar container configuration
   sidecar:
-    image: aronmuon/librecodeinterpreter-sidecar:latest
+    image: aronmuon/kubecoderun-sidecar:latest
     port: 8080
 
   # Per-language pool configuration
@@ -168,40 +168,40 @@ execution:
   # poolSize = 0: use Jobs (cold start)
   languages:
     python:
-      image: aronmuon/librecodeinterpreter-python:latest
+      image: aronmuon/kubecoderun-python:latest
       poolSize: 5
     javascript:
-      image: aronmuon/librecodeinterpreter-javascript:latest
+      image: aronmuon/kubecoderun-javascript:latest
       poolSize: 2
     typescript:
-      image: aronmuon/librecodeinterpreter-typescript:latest
+      image: aronmuon/kubecoderun-typescript:latest
       poolSize: 0
     go:
-      image: aronmuon/librecodeinterpreter-go:latest
+      image: aronmuon/kubecoderun-go:latest
       poolSize: 0
     java:
-      image: aronmuon/librecodeinterpreter-java:latest
+      image: aronmuon/kubecoderun-java:latest
       poolSize: 0
     rust:
-      image: aronmuon/librecodeinterpreter-rust:latest
+      image: aronmuon/kubecoderun-rust:latest
       poolSize: 0
     c:
-      image: aronmuon/librecodeinterpreter-c-cpp:latest
+      image: aronmuon/kubecoderun-c-cpp:latest
       poolSize: 0
     cpp:
-      image: aronmuon/librecodeinterpreter-c-cpp:latest
+      image: aronmuon/kubecoderun-c-cpp:latest
       poolSize: 0
     php:
-      image: aronmuon/librecodeinterpreter-php:latest
+      image: aronmuon/kubecoderun-php:latest
       poolSize: 0
     r:
-      image: aronmuon/librecodeinterpreter-r:latest
+      image: aronmuon/kubecoderun-r:latest
       poolSize: 0
     fortran:
-      image: aronmuon/librecodeinterpreter-fortran:latest
+      image: aronmuon/kubecoderun-fortran:latest
       poolSize: 0
     d:
-      image: aronmuon/librecodeinterpreter-d:latest
+      image: aronmuon/kubecoderun-d:latest
       poolSize: 0
 
   # Job settings (for languages with poolSize=0)
@@ -259,7 +259,7 @@ secretsStore:
   objects: []
   # Example:
   # - secretArn: "arn:aws:secretsmanager:us-west-2:123456789:secret:my-secret"
-  #   objectAlias: "code-interpreter-env"
+  #   objectAlias: "kubecoderun-env"
   #   jmesPath:
   #     - path: "REDIS_URL"
   #       objectAlias: "REDIS_URL"

--- a/scripts/load_test/monitor.py
+++ b/scripts/load_test/monitor.py
@@ -163,10 +163,10 @@ class ResourceMonitor:
                 except (json.JSONDecodeError, ValueError):
                     continue
 
-            # Filter for code-interpreter containers only
+            # Filter for kubecoderun containers only
             code_interpreter_containers = [
                 c for c in containers
-                if "code-interpreter" in c["name"].lower() or "executor" in c["name"].lower()
+                if "kubecoderun" in c["name"].lower() or "executor" in c["name"].lower()
             ]
 
             return DockerStats(

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -21,7 +21,7 @@ async def basic_health_check():
         "status": "healthy",
         "version": "1.1.1",
         "timestamp": "2025-01-18T00:00:00Z",
-        "service": "code-interpreter-api",
+        "service": "kubecoderun-api",
     }
 
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
     minio_access_key: Optional[str] = Field(default=None)
     minio_secret_key: Optional[str] = Field(default=None)
     minio_secure: bool = Field(default=False)
-    minio_bucket: str = Field(default="code-interpreter-files")
+    minio_bucket: str = Field(default="kubecoderun-files")
     minio_region: str = Field(default="us-east-1")
     minio_use_iam: bool = Field(
         default=False,
@@ -119,11 +119,11 @@ class Settings(BaseSettings):
         description="Namespace for execution pods (empty = use API's namespace)",
     )
     k8s_service_account: str = Field(
-        default="librecodeinterpreter-executor",
+        default="kubecoderun-executor",
         description="Service account for execution pods",
     )
     k8s_sidecar_image: str = Field(
-        default="aronmuon/librecodeinterpreter-sidecar:latest",
+        default="aronmuon/kubecoderun-sidecar:latest",
         description="Sidecar container image for pod communication",
     )
     k8s_sidecar_port: int = Field(
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
         description="Maximum execution time for Jobs",
     )
     k8s_image_registry: str = Field(
-        default="aronmuon/librecodeinterpreter",
+        default="aronmuon/kubecoderun",
         description="Container image registry prefix (images: {registry}-{language}:{tag})",
     )
     k8s_image_tag: str = Field(
@@ -248,7 +248,7 @@ class Settings(BaseSettings):
         description="Enable WAN-only network access for execution pods",
     )
     wan_network_name: str = Field(
-        default="code-interpreter-wan",
+        default="kubecoderun-wan",
         description="Network name for WAN-access pods",
     )
     wan_dns_servers: List[str] = Field(
@@ -405,7 +405,7 @@ class Settings(BaseSettings):
             if data.get("supported_languages"):
                 return data
 
-            registry = data.get("k8s_image_registry", "aronmuon/librecodeinterpreter")
+            registry = data.get("k8s_image_registry", "aronmuon/kubecoderun")
             tag = data.get("k8s_image_tag", "latest")
             data["supported_languages"] = {
                 code: {

--- a/src/config/kubernetes.py
+++ b/src/config/kubernetes.py
@@ -15,10 +15,10 @@ class KubernetesConfig:
     namespace: str = ""
 
     # Service account for execution pods
-    service_account: str = "librecodeinterpreter-executor"
+    service_account: str = "kubecoderun-executor"
 
     # Sidecar configuration
-    sidecar_image: str = "aronmuon/librecodeinterpreter-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
     sidecar_port: int = 8080
 
     # Resource limits for execution pods
@@ -48,8 +48,8 @@ class KubernetesConfig:
 
     # Image registry configuration
     # Format: {image_registry}-{language}:{image_tag}
-    # e.g., aronmuon/librecodeinterpreter-python:latest
-    image_registry: str = "aronmuon/librecodeinterpreter"
+    # e.g., aronmuon/kubecoderun-python:latest
+    image_registry: str = "aronmuon/kubecoderun"
     image_tag: str = "latest"
 
     def get_image_for_language(self, language: str) -> str:

--- a/src/config/languages.py
+++ b/src/config/languages.py
@@ -189,7 +189,7 @@ def get_image_for_language(
     """Get container image for a language.
 
     Image format: {registry}-{base_image}:{tag}
-    e.g., aronmuon/librecodeinterpreter-python:latest
+    e.g., aronmuon/kubecoderun-python:latest
     """
     lang = get_language(code)
     if lang:

--- a/src/config/minio.py
+++ b/src/config/minio.py
@@ -21,7 +21,7 @@ class MinIOConfig(BaseSettings):
     access_key: Optional[str] = Field(default=None, alias="minio_access_key")
     secret_key: Optional[str] = Field(default=None, alias="minio_secret_key")
     secure: bool = Field(default=False, alias="minio_secure")
-    bucket: str = Field(default="code-interpreter-files", alias="minio_bucket")
+    bucket: str = Field(default="kubecoderun-files", alias="minio_bucket")
     region: str = Field(default="us-east-1", alias="minio_region")
     use_iam: bool = Field(default=False, alias="minio_use_iam")
 

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -41,7 +41,7 @@ class JobExecutor:
         namespace: Optional[str] = None,
         ttl_seconds_after_finished: int = 60,
         active_deadline_seconds: int = 300,
-        sidecar_image: str = "aronmuon/librecodeinterpreter-sidecar:latest",
+        sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest",
     ):
         """Initialize the Job executor.
 
@@ -97,12 +97,12 @@ class JobExecutor:
         namespace = spec.namespace or self.namespace
 
         labels = {
-            "app.kubernetes.io/name": "librecodeinterpreter",
+            "app.kubernetes.io/name": "kubecoderun",
             "app.kubernetes.io/component": "execution",
-            "app.kubernetes.io/managed-by": "librecodeinterpreter",
-            "librecodeinterpreter.io/language": spec.language,
-            "librecodeinterpreter.io/session-id": session_id[:63],
-            "librecodeinterpreter.io/type": "job",
+            "app.kubernetes.io/managed-by": "kubecoderun",
+            "kubecoderun.io/language": spec.language,
+            "kubecoderun.io/session-id": session_id[:63],
+            "kubecoderun.io/type": "job",
             **spec.labels,
         }
 

--- a/src/services/kubernetes/manager.py
+++ b/src/services/kubernetes/manager.py
@@ -39,7 +39,7 @@ class KubernetesManager:
         self,
         namespace: Optional[str] = None,
         pool_configs: Optional[List[PoolConfig]] = None,
-        sidecar_image: str = "aronmuon/librecodeinterpreter-sidecar:latest",
+        sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest",
         default_cpu_limit: str = "1",
         default_memory_limit: str = "512Mi",
         default_cpu_request: str = "100m",
@@ -77,15 +77,15 @@ class KubernetesManager:
 
         # Language image mappings (can be overridden by pool configs)
         self._language_images: Dict[str, str] = {
-            "python": "aronmuon/librecodeinterpreter-python:latest",
-            "py": "aronmuon/librecodeinterpreter-python:latest",
-            "javascript": "aronmuon/librecodeinterpreter-javascript:latest",
-            "js": "aronmuon/librecodeinterpreter-javascript:latest",
-            "typescript": "aronmuon/librecodeinterpreter-typescript:latest",
-            "ts": "aronmuon/librecodeinterpreter-typescript:latest",
-            "go": "aronmuon/librecodeinterpreter-go:latest",
-            "rust": "aronmuon/librecodeinterpreter-rust:latest",
-            "rs": "aronmuon/librecodeinterpreter-rust:latest",
+            "python": "aronmuon/kubecoderun-python:latest",
+            "py": "aronmuon/kubecoderun-python:latest",
+            "javascript": "aronmuon/kubecoderun-javascript:latest",
+            "js": "aronmuon/kubecoderun-javascript:latest",
+            "typescript": "aronmuon/kubecoderun-typescript:latest",
+            "ts": "aronmuon/kubecoderun-typescript:latest",
+            "go": "aronmuon/kubecoderun-go:latest",
+            "rust": "aronmuon/kubecoderun-rust:latest",
+            "rs": "aronmuon/kubecoderun-rust:latest",
         }
 
         # Track active executions
@@ -150,7 +150,7 @@ class KubernetesManager:
         # Fall back to default mapping
         return self._language_images.get(
             language.lower(),
-            f"aronmuon/librecodeinterpreter-{language}:latest",
+            f"aronmuon/kubecoderun-{language}:latest",
         )
 
     def uses_pool(self, language: str) -> bool:

--- a/src/services/kubernetes/models.py
+++ b/src/services/kubernetes/models.py
@@ -112,7 +112,7 @@ class PodSpec:
     run_as_non_root: bool = True
 
     # Sidecar configuration
-    sidecar_image: str = "aronmuon/librecodeinterpreter-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
     sidecar_port: int = 8080
 
 
@@ -123,7 +123,7 @@ class PoolConfig:
     language: str
     image: str
     pool_size: int = 0  # 0 = use Jobs instead of pool
-    sidecar_image: str = "aronmuon/librecodeinterpreter-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
 
     # Resource limits (can override defaults)
     cpu_limit: Optional[str] = None

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -165,12 +165,12 @@ class PodPool:
         pod_name = self._generate_pod_name()
 
         labels = {
-            "app.kubernetes.io/name": "librecodeinterpreter",
+            "app.kubernetes.io/name": "kubecoderun",
             "app.kubernetes.io/component": "execution",
-            "app.kubernetes.io/managed-by": "librecodeinterpreter",
-            "librecodeinterpreter.io/language": self.language,
-            "librecodeinterpreter.io/type": "pool",
-            "librecodeinterpreter.io/pool-status": "warm",
+            "app.kubernetes.io/managed-by": "kubecoderun",
+            "kubecoderun.io/language": self.language,
+            "kubecoderun.io/type": "pool",
+            "kubecoderun.io/pool-status": "warm",
         }
 
         pod_manifest = create_pod_manifest(

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -110,7 +110,7 @@ def configure_third_party_loggers() -> None:
 
 def add_service_context(logger, method_name, event_dict):
     """Add service context information to log entries."""
-    event_dict["service"] = "code-interpreter-api"
+    event_dict["service"] = "kubecoderun-api"
     event_dict["version"] = "1.0.0"
     return event_dict
 


### PR DESCRIPTION
## Description

Rebrands the project to **KubeCodeRun** and improves contributor attribution following open source best practices.

### Changes

- Renamed project references from LibreCodeInterpreter to KubeCodeRun across all files
- Added dedicated **Acknowledgments** section in README to properly credit [@usnavy13](https://github.com/usnavy13) for the original [LibreCodeInterpreter](https://github.com/usnavy13/LibreCodeInterpreter) project
- Updated repository URLs and project naming throughout documentation

## Type of change

- [x] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings