### PR TITLE
fix: prevent command injection via working_dir parameter in sidecar

### DIFF
--- a/docker/sidecar/main.py
+++ b/docker/sidecar/main.py
@@ -10,6 +10,7 @@ Requires: shareProcessNamespace: true in the pod spec.
 
 import asyncio
 import os
+import shlex
 import time
 import traceback
 from contextlib import asynccontextmanager
@@ -137,9 +138,11 @@ def get_language_command(language: str, code: str, working_dir: str) -> tuple[li
     """
     # Helper to wrap command with cd to working directory
     def wrap_cmd(cmd: str, env_setup: str = "") -> list[str]:
+        # Sanitize working_dir to prevent command injection
+        safe_working_dir = shlex.quote(working_dir)
         if env_setup:
-            return ["sh", "-c", f"{env_setup} cd {working_dir} && {cmd}"]
-        return ["sh", "-c", f"cd {working_dir} && {cmd}"]
+            return ["sh", "-c", f"{env_setup} cd {safe_working_dir} && {cmd}"]
+        return ["sh", "-c", f"cd {safe_working_dir} && {cmd}"]
 
     # Environment setup strings for each language runtime
     # These match the ENTRYPOINT environment in each language's Dockerfile


### PR DESCRIPTION
## Summary
**This isn't currently exploitable, it's just a defense-in-depth change**

- Apply `shlex.quote()` to sanitize the `working_dir` parameter before shell command interpolation in `wrap_cmd()`
- Defense-in-depth fix for the sidecar HTTP API

## Context
The `wrap_cmd` function in `docker/sidecar/main.py` directly interpolates `working_dir` into shell commands without sanitization, which looks dangerous.

The current mitigation is that the code writes `code.py` to the `working_dir` *before* the shell command is constructed:

```python
code_file = Path(working_dir) / "code.py"
code_file.write_text(code)  # Fails if directory doesn't exist
return wrap_cmd(f"python3 {code_file}", ...)  # Never reached
```

A malicious path like `/tmp; id #` fails at `write_text()` with `FileNotFoundError` because no such directory exists - the shell command is never executed.

**Why merge?** The fix is a simple 2-line change that adds proper input sanitization. It's good practice and provides defense-in-depth if:
- The code flow changes in the future
- Someone creates a directory with shell metacharacters
- We add code paths that don't write files first

## Test plan
- [x] Linting
- [x] Format check
- [x] Unit tests
- [x] Tested code execution in test cluster