### PR TITLE
fix: just test warnings

### DIFF
--- a/src/models/errors.py
+++ b/src/models/errors.py
@@ -4,7 +4,7 @@ import time
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ErrorType(str, Enum):
@@ -41,8 +41,7 @@ class ErrorResponse(BaseModel):
     request_id: str | None = Field(None, description="Request identifier for tracking")
     timestamp: float = Field(default_factory=time.time, description="Error timestamp")
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 # Custom Exception Classes

--- a/src/models/exec.py
+++ b/src/models/exec.py
@@ -1,7 +1,6 @@
 """Models for the /exec endpoint compatible with LibreChat API."""
 
 # Standard library imports
-from datetime import datetime
 from typing import Any, List, Optional
 
 # Third-party imports
@@ -62,6 +61,3 @@ class ExecResponse(BaseModel):
     )
     state_size: int | None = Field(default=None, description="Compressed state size in bytes")
     state_hash: str | None = Field(default=None, description="SHA256 hash for ETag/change detection")
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}

--- a/src/models/execution.py
+++ b/src/models/execution.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import List, Optional
 
 # Third-party imports
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class ExecutionStatus(str, Enum):
@@ -39,6 +39,10 @@ class ExecutionOutput(BaseModel):
     size: int | None = Field(default=None, description="Size in bytes for file outputs")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, value: datetime) -> str:
+        return value.isoformat()
+
 
 class CodeExecution(BaseModel):
     """Model for code execution request and response."""
@@ -63,8 +67,9 @@ class CodeExecution(BaseModel):
     execution_time_ms: int | None = Field(default=None)
     memory_peak_mb: float | None = Field(default=None)
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("created_at", "started_at", "completed_at")
+    def serialize_datetime(self, value: datetime | None) -> str | None:
+        return value.isoformat() if value else None
 
 
 class ExecuteCodeRequest(BaseModel):
@@ -84,6 +89,3 @@ class ExecuteCodeResponse(BaseModel):
     exit_code: int | None = None
     error_message: str | None = None
     execution_time_ms: int | None = None
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}

--- a/src/models/files.py
+++ b/src/models/files.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import List, Optional
 
 # Third-party imports
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class FileUploadRequest(BaseModel):
@@ -25,8 +25,9 @@ class FileUploadResponse(BaseModel):
     upload_url: str = Field(..., description="Pre-signed URL for file upload")
     expires_at: datetime = Field(..., description="URL expiration time")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("expires_at")
+    def serialize_expires_at(self, value: datetime) -> str:
+        return value.isoformat()
 
 
 class FileInfo(BaseModel):
@@ -39,8 +40,9 @@ class FileInfo(BaseModel):
     created_at: datetime
     path: str = Field(..., description="File path in the session")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("created_at")
+    def serialize_created_at(self, value: datetime) -> str:
+        return value.isoformat()
 
 
 class FileListResponse(BaseModel):
@@ -59,8 +61,9 @@ class FileDownloadResponse(BaseModel):
     download_url: str = Field(..., description="Pre-signed URL for file download")
     expires_at: datetime = Field(..., description="URL expiration time")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("expires_at")
+    def serialize_expires_at(self, value: datetime) -> str:
+        return value.isoformat()
 
 
 class FileDeleteResponse(BaseModel):

--- a/src/models/session.py
+++ b/src/models/session.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 # Third-party imports
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class SessionStatus(str, Enum):
@@ -52,8 +52,9 @@ class Session(BaseModel):
     # Metadata
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional session metadata")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("created_at", "last_activity", "expires_at")
+    def serialize_datetime(self, value: datetime) -> str:
+        return value.isoformat()
 
 
 class SessionCreate(BaseModel):
@@ -71,5 +72,6 @@ class SessionResponse(BaseModel):
     expires_at: datetime
     message: str | None = None
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("created_at", "expires_at")
+    def serialize_datetime(self, value: datetime) -> str:
+        return value.isoformat()

--- a/src/models/state.py
+++ b/src/models/state.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class StateInfo(BaseModel):
@@ -20,8 +20,9 @@ class StateInfo(BaseModel):
     expires_at: datetime | None = Field(None, description="When state will expire")
     source: str | None = Field(None, description="Storage source: 'redis' or 'archive'")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat() if v else None}
+    @field_serializer("created_at", "expires_at")
+    def serialize_datetime(self, value: datetime | None) -> str | None:
+        return value.isoformat() if value else None
 
 
 class StateUploadResponse(BaseModel):

--- a/tests/integration/test_api_contracts.py
+++ b/tests/integration/test_api_contracts.py
@@ -128,7 +128,7 @@ def mock_file_service():
         filename="test.txt",
         size=1024,
         content_type="text/plain",
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
         path="/test.txt",
     )
     service.download_file.return_value = "https://minio.example.com/download-url"
@@ -317,7 +317,7 @@ class TestExecResponseFormat:
                 filename="output.txt",
                 size=100,
                 content_type="text/plain",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 path="/output.txt",
             )
         ]

--- a/tests/integration/test_container_behavior.py
+++ b/tests/integration/test_container_behavior.py
@@ -514,7 +514,7 @@ class TestFileGeneration:
                 filename="output.txt",
                 size=100,
                 content_type="text/plain",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 path="/output.txt",
             )
         ]
@@ -577,7 +577,7 @@ class TestFileGeneration:
                 filename="file1.txt",
                 size=50,
                 content_type="text/plain",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 path="/file1.txt",
             ),
             FileInfo(
@@ -585,7 +585,7 @@ class TestFileGeneration:
                 filename="file2.csv",
                 size=100,
                 content_type="text/csv",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 path="/file2.csv",
             ),
         ]

--- a/tests/integration/test_librechat_compat.py
+++ b/tests/integration/test_librechat_compat.py
@@ -478,18 +478,21 @@ class TestLibreChatFileRetrieval:
         LibreChat downloads generated files using this endpoint.
         From crud.js: GET /download/{session_id}/{fileId}
         """
-        # Mock file service to return file content
-        self.mock_file_service.get_file.return_value = (
-            io.BytesIO(b"file content here"),
-            "output.txt",
-            "text/plain",
+        # Mock file service to return file info and content
+        self.mock_file_service.get_file_info.return_value = FileInfo(
+            file_id="file-abc",
+            filename="output.txt",
+            size=17,
+            content_type="text/plain",
+            created_at=datetime.now(UTC),
+            path="/output.txt",
         )
+        self.mock_file_service.get_file_content.return_value = b"file content here"
 
         response = client.get("/download/test-session-789/file-abc", headers=auth_headers)
 
-        # Should return file content or appropriate response
-        # Note: Actual status depends on whether file exists in mock
-        assert response.status_code in [200, 404]
+        # Should return file content
+        assert response.status_code == 200
 
 
 # =============================================================================

--- a/tests/integration/test_security_integration.py
+++ b/tests/integration/test_security_integration.py
@@ -107,7 +107,7 @@ class TestSecurityIntegration:
             "content-type": "application/xml",  # Not allowed
         }
 
-        response = client.post("/sessions", data="<xml></xml>", headers=headers)
+        response = client.post("/sessions", content="<xml></xml>", headers=headers)
         assert response.status_code == 415  # Unsupported Media Type
 
     def test_multiple_auth_methods(self, client):

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -141,6 +141,9 @@ async def test_delete_session(session_service, mock_redis):
     """Test deleting a session."""
     session_id = "test-session-id"
 
+    # Mock get_session to return None (session doesn't exist, skip cleanup)
+    mock_redis.hgetall.return_value = {}
+
     # The pipeline mock is already set up in the fixture
     pipeline_mock = mock_redis.pipeline.return_value
     pipeline_mock.execute.return_value = [1, 1]  # Both operations successful

--- a/tests/unit/test_state_service.py
+++ b/tests/unit/test_state_service.py
@@ -259,7 +259,12 @@ class TestGetFullStateInfo:
     @pytest.mark.asyncio
     async def test_get_full_state_info_returns_none_when_no_state(self, state_service, mock_redis_client):
         """Test that get_full_state_info returns None when no state."""
-        mock_pipe = AsyncMock()
+        mock_pipe = MagicMock()
+        # Pipeline methods are sync (they just queue commands)
+        mock_pipe.strlen = MagicMock()
+        mock_pipe.ttl = MagicMock()
+        mock_pipe.get = MagicMock()
+        # Only execute is async
         mock_pipe.execute = AsyncMock(return_value=[0, -1, None])
         mock_redis_client.pipeline.return_value = mock_pipe
 


### PR DESCRIPTION
## Summary

Fix all deprecation and runtime warnings from test suite to prepare for Pydantic V3 and Python 3.13+ compatibility.

### Changes

**Pydantic V2 Migration (6 model files):**
- Replace deprecated `class Config:` with `model_config = ConfigDict()` for enum serialization
- Replace deprecated `json_encoders` with `@field_serializer` decorators for datetime fields
- Remove unused datetime import from `exec.py` (model had no datetime fields)

**Python 3.13 Deprecations (2 test files):**
- Replace `datetime.utcnow()` with `datetime.now(UTC)` in test fixtures

**Test Mock Fixes (4 test files):**
- Fix AsyncMock warnings by properly mocking `hgetall` return value in session delete test
- Fix pipeline mock to use `MagicMock` for sync queue methods (strlen, ttl, get) instead of AsyncMock
- Fix `test_download_endpoint` to mock correct methods (`get_file_info`, `get_file_content`) instead of non-existent `get_file`
- Use `content=` instead of deprecated `data=` for raw content in httpx test client

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `just test-unit` - All unit tests pass with no warnings
- [x] `just test` - Full test suite passes with no warnings

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
