### PR TITLE
test: test warnings

### DIFF
--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -10,8 +10,8 @@ from src.core.events import Event, EventBus
 
 
 @dataclass
-class TestEvent(Event):
-    """Test event for testing."""
+class SampleEvent(Event):
+    """Sample event for testing."""
 
     value: str = "test"
 
@@ -35,27 +35,27 @@ class TestEventBusRegister:
     def test_register_handler(self, event_bus):
         """Test registering a handler."""
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler)
+        event_bus.register_handler(SampleEvent, handler)
 
-        assert TestEvent in event_bus._handlers
-        assert handler in event_bus._handlers[TestEvent]
+        assert SampleEvent in event_bus._handlers
+        assert handler in event_bus._handlers[SampleEvent]
 
     def test_register_multiple_handlers(self, event_bus):
         """Test registering multiple handlers for same event."""
 
-        async def handler1(event: TestEvent):
+        async def handler1(event: SampleEvent):
             pass
 
-        async def handler2(event: TestEvent):
+        async def handler2(event: SampleEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler1)
-        event_bus.register_handler(TestEvent, handler2)
+        event_bus.register_handler(SampleEvent, handler1)
+        event_bus.register_handler(SampleEvent, handler2)
 
-        assert len(event_bus._handlers[TestEvent]) == 2
+        assert len(event_bus._handlers[SampleEvent]) == 2
 
 
 class TestEventBusUnregister:
@@ -64,32 +64,32 @@ class TestEventBusUnregister:
     def test_unregister_handler_success(self, event_bus):
         """Test unregistering an existing handler."""
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler)
-        result = event_bus.unregister_handler(TestEvent, handler)
+        event_bus.register_handler(SampleEvent, handler)
+        result = event_bus.unregister_handler(SampleEvent, handler)
 
         assert result is True
-        assert handler not in event_bus._handlers[TestEvent]
+        assert handler not in event_bus._handlers[SampleEvent]
 
     def test_unregister_handler_not_found(self, event_bus):
         """Test unregistering a handler that doesn't exist."""
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             pass
 
-        result = event_bus.unregister_handler(TestEvent, handler)
+        result = event_bus.unregister_handler(SampleEvent, handler)
 
         assert result is False
 
     def test_unregister_handler_wrong_event_type(self, event_bus):
         """Test unregistering from wrong event type."""
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler)
+        event_bus.register_handler(SampleEvent, handler)
         result = event_bus.unregister_handler(OtherEvent, handler)
 
         assert result is False
@@ -101,7 +101,7 @@ class TestEventBusPublish:
     @pytest.mark.asyncio
     async def test_publish_no_handlers(self, event_bus):
         """Test publishing with no handlers."""
-        event = TestEvent(value="test")
+        event = SampleEvent(value="test")
 
         # Should not raise
         await event_bus.publish(event)
@@ -111,11 +111,11 @@ class TestEventBusPublish:
         """Test publishing calls handler."""
         called_with = []
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             called_with.append(event)
 
-        event_bus.register_handler(TestEvent, handler)
-        event = TestEvent(value="hello")
+        event_bus.register_handler(SampleEvent, handler)
+        event = SampleEvent(value="hello")
 
         await event_bus.publish(event)
 
@@ -127,17 +127,17 @@ class TestEventBusPublish:
         """Test publishing calls all handlers concurrently."""
         results = []
 
-        async def handler1(event: TestEvent):
+        async def handler1(event: SampleEvent):
             await asyncio.sleep(0.01)
             results.append("handler1")
 
-        async def handler2(event: TestEvent):
+        async def handler2(event: SampleEvent):
             results.append("handler2")
 
-        event_bus.register_handler(TestEvent, handler1)
-        event_bus.register_handler(TestEvent, handler2)
+        event_bus.register_handler(SampleEvent, handler1)
+        event_bus.register_handler(SampleEvent, handler2)
 
-        await event_bus.publish(TestEvent())
+        await event_bus.publish(SampleEvent())
 
         assert len(results) == 2
         assert "handler1" in results
@@ -148,17 +148,17 @@ class TestEventBusPublish:
         """Test publishing handles handler errors gracefully."""
         good_handler_called = []
 
-        async def error_handler(event: TestEvent):
+        async def error_handler(event: SampleEvent):
             raise ValueError("Handler error")
 
-        async def good_handler(event: TestEvent):
+        async def good_handler(event: SampleEvent):
             good_handler_called.append(True)
 
-        event_bus.register_handler(TestEvent, error_handler)
-        event_bus.register_handler(TestEvent, good_handler)
+        event_bus.register_handler(SampleEvent, error_handler)
+        event_bus.register_handler(SampleEvent, good_handler)
 
         # Should not raise despite handler error
-        await event_bus.publish(TestEvent())
+        await event_bus.publish(SampleEvent())
 
         # Good handler should still be called
         assert len(good_handler_called) == 1
@@ -171,11 +171,11 @@ class TestEventBusPublishAndWait:
     async def test_publish_and_wait_no_errors(self, event_bus):
         """Test publish_and_wait returns empty list on success."""
 
-        async def handler(event: TestEvent):
+        async def handler(event: SampleEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler)
-        errors = await event_bus.publish_and_wait(TestEvent())
+        event_bus.register_handler(SampleEvent, handler)
+        errors = await event_bus.publish_and_wait(SampleEvent())
 
         assert errors == []
 
@@ -183,16 +183,16 @@ class TestEventBusPublishAndWait:
     async def test_publish_and_wait_collects_errors(self, event_bus):
         """Test publish_and_wait collects all errors."""
 
-        async def error_handler(event: TestEvent):
+        async def error_handler(event: SampleEvent):
             raise ValueError("Error 1")
 
-        async def another_error_handler(event: TestEvent):
+        async def another_error_handler(event: SampleEvent):
             raise RuntimeError("Error 2")
 
-        event_bus.register_handler(TestEvent, error_handler)
-        event_bus.register_handler(TestEvent, another_error_handler)
+        event_bus.register_handler(SampleEvent, error_handler)
+        event_bus.register_handler(SampleEvent, another_error_handler)
 
-        errors = await event_bus.publish_and_wait(TestEvent())
+        errors = await event_bus.publish_and_wait(SampleEvent())
 
         assert len(errors) == 2
         assert any(isinstance(e, ValueError) for e in errors)
@@ -201,7 +201,7 @@ class TestEventBusPublishAndWait:
     @pytest.mark.asyncio
     async def test_publish_and_wait_no_handlers(self, event_bus):
         """Test publish_and_wait with no handlers."""
-        errors = await event_bus.publish_and_wait(TestEvent())
+        errors = await event_bus.publish_and_wait(SampleEvent())
 
         assert errors == []
 
@@ -212,30 +212,30 @@ class TestEventBusClearHandlers:
     def test_clear_handlers_specific_type(self, event_bus):
         """Test clearing handlers for specific event type."""
 
-        async def handler1(event: TestEvent):
+        async def handler1(event: SampleEvent):
             pass
 
         async def handler2(event: OtherEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler1)
+        event_bus.register_handler(SampleEvent, handler1)
         event_bus.register_handler(OtherEvent, handler2)
 
-        event_bus.clear_handlers(TestEvent)
+        event_bus.clear_handlers(SampleEvent)
 
-        assert TestEvent not in event_bus._handlers
+        assert SampleEvent not in event_bus._handlers
         assert OtherEvent in event_bus._handlers
 
     def test_clear_handlers_all(self, event_bus):
         """Test clearing all handlers."""
 
-        async def handler1(event: TestEvent):
+        async def handler1(event: SampleEvent):
             pass
 
         async def handler2(event: OtherEvent):
             pass
 
-        event_bus.register_handler(TestEvent, handler1)
+        event_bus.register_handler(SampleEvent, handler1)
         event_bus.register_handler(OtherEvent, handler2)
 
         event_bus.clear_handlers()
@@ -245,4 +245,4 @@ class TestEventBusClearHandlers:
     def test_clear_handlers_nonexistent_type(self, event_bus):
         """Test clearing handlers for type that has none."""
         # Should not raise
-        event_bus.clear_handlers(TestEvent)
+        event_bus.clear_handlers(SampleEvent)

--- a/tests/unit/test_shutdown.py
+++ b/tests/unit/test_shutdown.py
@@ -131,9 +131,11 @@ class TestShutdown:
 
         # Use a shorter timeout for testing - but the real code has 10s timeout
         # Just verify it doesn't hang forever
-        with patch("src.utils.shutdown.asyncio.wait_for", new_callable=AsyncMock) as mock_wait:
-            mock_wait.side_effect = TimeoutError()
+        async def timeout_side_effect(coro, timeout):
+            coro.close()  # Clean up the coroutine to avoid warning
+            raise TimeoutError()
 
+        with patch("src.utils.shutdown.asyncio.wait_for", side_effect=timeout_side_effect):
             # Should not raise
             await handler.shutdown()
 


### PR DESCRIPTION
## Summary

Fixes pytest warnings in the test suite.

### Changes

- **test_events.py**: Renamed `TestEvent` dataclass to `SampleEvent` to avoid `PytestCollectionWarning` (pytest was trying to collect it as a test class)
- **test_shutdown.py**: Fixed unawaited coroutine warning by properly closing the coroutine in the mock before raising `TimeoutError`
- **test_orchestrator.py**: Renamed duplicate `TestCleanup` class to `TestCleanupExtended` to fix ruff F811 lint error
