### PR TITLE
fix: file transfer bug

### DIFF
--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -35,6 +35,7 @@ def mock_file_service():
     service.get_file_info = AsyncMock(return_value=None)
     service.list_files = AsyncMock(return_value=[])
     service.upload_file = AsyncMock()
+    service.get_file_content = AsyncMock(return_value=b"test content")
     return service
 
 
@@ -495,6 +496,8 @@ class TestMountFilesExtended:
         assert len(result) == 1
         assert result[0]["file_id"] == "file-123"
         assert result[0]["filename"] == "test.txt"
+        assert result[0]["content"] == b"test content"
+        mock_file_service.get_file_content.assert_called_once_with("session-123", "file-123")
 
     @pytest.mark.asyncio
     async def test_mount_files_file_not_found(self, orchestrator, mock_file_service):
@@ -539,6 +542,7 @@ class TestMountFilesExtended:
 
         assert len(result) == 1
         assert result[0]["file_id"] == "file-456"
+        assert result[0]["content"] == b"test content"
 
     @pytest.mark.asyncio
     async def test_mount_files_skip_duplicates(self, orchestrator, mock_file_service):


### PR DESCRIPTION
## Summary

Files uploaded via `session_id` were not being transferred to Kubernetes execution pods. The orchestrator collected file metadata but never fetched the actual file content from MinIO storage.

### Problem Flow

1. **User uploads a file** - File stored in MinIO, metadata saved in Redis
2. **User executes code with `session_id`** - Orchestrator calls `_mount_files()`
3. **`_mount_files()` fetched file metadata** - But did NOT fetch actual file bytes
4. **Files passed to `KubernetesManager.execute_code()`** - Missing `content` field
5. **Manager filters out files without bytes content**:
   ```python
   # In kubernetes/manager.py
   file_data = [
       FileData(...)
       for f in files
       if isinstance(f.get("content"), bytes)  # <-- All files filtered out!
   ]
   ```
6. **Result**: No files were transferred to the pod

### Solution

Modified `_mount_files()` in `src/services/orchestrator.py` to:

1. **Fetch actual file content** - Call `self.file_service.get_file_content()` after finding file info
2. **Include content in mounted files** - Add `"content": content` to the file dictionary
3. **Add error handling** - Skip files if content fetch fails with warning log
4. **Improved file lookup** - Enhanced fallback to also match by `file_id` in addition to filename
5. **Add debug logging** - Log mounted files with their content size

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] All 1260 unit tests pass
- [x] Linting passes (`just lint`)
- [x] Type checking passes (`just typecheck`)
- [x] Updated unit tests to verify content is included in mounted files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes