### PR TITLE
fix: tagged version now is tagged properly

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,13 +109,15 @@ jobs:
             SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
             echo "image_tag=dev-${SHORT_SHA}" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # Tag push or workflow_dispatch triggered with a tag ref
+            echo "image_tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            # workflow_dispatch on a branch or other non-tag ref
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
             echo "image_tag=dev-${SHORT_SHA}" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
-          else
-            echo "image_tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
           fi
 
   # ==================== Build Jobs ====================

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# KubeCodeRun API server with Docker Hardened Images!
+# KubeCodeRun API server with Docker Hardened Images.
 
 ARG BUILD_DATE
 ARG VERSION=0.0.0-dev

--- a/docker/c-cpp.Dockerfile
+++ b/docker/c-cpp.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# C/C++ execution environment with Docker Hardened Images!
+# C/C++ execution environment with Docker Hardened Images.
 
 FROM dhi.io/debian-base:trixie
 

--- a/docker/d.Dockerfile
+++ b/docker/d.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# D execution environment with Docker Hardened Images!
+# D execution environment with Docker Hardened Images.
 
 FROM dhi.io/debian-base:trixie
 

--- a/docker/fortran.Dockerfile
+++ b/docker/fortran.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Fortran execution environment with Docker Hardened Images!
+# Fortran execution environment with Docker Hardened Images.
 
 FROM dhi.io/debian-base:trixie
 

--- a/docker/go.Dockerfile
+++ b/docker/go.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Go execution environment using Docker Hardened Images!
+# Go execution environment using Docker Hardened Images.
 
 ################################
 # Stage 1: Build and download dependencies

--- a/docker/java.Dockerfile
+++ b/docker/java.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Java execution environment with Docker Hardened Images!
+# Java execution environment with Docker Hardened Images.
 
 ARG BUILD_DATE
 ARG VERSION

--- a/docker/nodejs.Dockerfile
+++ b/docker/nodejs.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Node.js execution environment with BuildKit optimizations.
-# Uses Docker Hardened Images (DHI) for security!
+# Uses Docker Hardened Images (DHI) for security.
 
 ARG BUILD_DATE
 ARG VERSION

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# PHP execution environment with Docker Hardened Images!
+# PHP execution environment with Docker Hardened Images.
 
 # PHP version configuration - single source of truth
 ARG PHP_VERSION=8.4.17

--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Python execution environment with Docker Hardened Images!
+# Python execution environment with Docker Hardened Images.
 
 ARG BUILD_DATE
 ARG VERSION

--- a/docker/r.Dockerfile
+++ b/docker/r.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# R execution environment with Docker Hardened Images!
+# R execution environment with Docker Hardened Images.
 # Uses debian-base since there is no DHI R image.
 
 ARG BUILD_DATE

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# Rust execution environment with Docker Hardened Images!
+# Rust execution environment with Docker Hardened Images.
 #
 # Pre-compiled crates from rust-Cargo.toml are available without recompilation.
 # CARGO_NET_OFFLINE=true prevents runtime downloads (security hardening).

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# KubeCodeRun HTTP sidecar with Docker Hardened Images!
+# KubeCodeRun HTTP sidecar with Docker Hardened Images.
 
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
## Summary

- Fix Docker image tagging to use release version instead of dev tag when triggered via `workflow_dispatch` with a tag ref

### Problem

When `release.yml` triggers `docker-publish.yml` via `workflow_dispatch` with `--ref refs/tags/v1.2.8`, the Docker images were incorrectly tagged as `dev-5e2537c` instead of `v1.2.8`.

This happened because the tag logic checked `github.event_name` first, and `workflow_dispatch` always fell into the dev tag branch regardless of the ref being a tag.

### Solution

Changed the logic to check `github.ref` pattern (`refs/tags/*`) instead of event type. Now both direct tag pushes and `workflow_dispatch` calls with tag refs correctly use the tag name and set `is_release=true`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified logic flow handles all three cases correctly:
  - `pull_request` → `dev-{sha}` tag, `is_release=false`
  - `refs/tags/*` (push or workflow_dispatch) → tag name, `is_release=true`
  - Other workflow_dispatch → `dev-{sha}` tag, `is_release=false`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
