### PR TITLE
feat(kubernetes): add agent execution mode, GKE Sandbox, and image pu…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ API_KEY_CACHE_TTL=300
 RATE_LIMIT_ENABLED=true
 
 # Redis Configuration
+# Deployment mode: standalone (default), cluster, or sentinel
+REDIS_MODE=standalone
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
@@ -41,6 +43,33 @@ REDIS_DB=0
 REDIS_MAX_CONNECTIONS=20
 REDIS_SOCKET_TIMEOUT=5
 REDIS_SOCKET_CONNECT_TIMEOUT=5
+
+# Optional key prefix — useful when sharing a Redis instance across environments
+# All keys will be stored as <prefix><key>  (e.g. "prod:sessions:abc")
+REDIS_KEY_PREFIX=
+
+# Redis Cluster Mode (REDIS_MODE=cluster)
+# Comma-separated list of host:port pairs for cluster startup nodes
+# REDIS_CLUSTER_NODES=node1:6379,node2:6379,node3:6379
+
+# Redis Sentinel Mode (REDIS_MODE=sentinel)
+# Comma-separated list of host:port pairs for Sentinel instances
+# REDIS_SENTINEL_NODES=sentinel1:26379,sentinel2:26379,sentinel3:26379
+# REDIS_SENTINEL_MASTER=mymaster
+# REDIS_SENTINEL_PASSWORD=
+
+# Redis TLS/SSL Configuration
+# Required for most managed Redis services (GCP Memorystore, AWS ElastiCache, Azure Cache)
+REDIS_TLS_ENABLED=false
+# REDIS_TLS_CA_CERT_FILE=/path/to/ca.crt
+# REDIS_TLS_CERT_FILE=/path/to/client.crt
+# REDIS_TLS_KEY_FILE=/path/to/client.key
+# REDIS_TLS_INSECURE=false
+# Hostname verification is off by default because managed Redis services
+# and Redis Cluster mode expose node IPs that don't match cert CN/SAN.
+# The CA certificate chain is still fully verified. Enable hostname
+# checking when your Redis server hostnames match certificate CN/SAN.
+# REDIS_TLS_CHECK_HOSTNAME=false
 
 # MinIO/S3 Configuration
 MINIO_ENDPOINT=localhost:9000
@@ -143,6 +172,37 @@ METRICS_ARCHIVE_RETENTION_DAYS=90
 # Security Configuration
 ENABLE_NETWORK_ISOLATION=true
 ENABLE_FILESYSTEM_ISOLATION=true
+
+# Kubernetes Execution Configuration
+# Execution mode: 'agent' (default, recommended) or 'nsenter' (legacy)
+#   agent:   Executor-agent binary runs inside the main container.
+#            No nsenter, no capabilities, no privilege escalation.
+#            Compatible with GKE Sandbox (gVisor) and restricted Pod Security Standards.
+#   nsenter: Sidecar uses nsenter to enter the main container's mount namespace.
+#            Requires shareProcessNamespace, SYS_PTRACE/SYS_ADMIN/SYS_CHROOT caps,
+#            and allowPrivilegeEscalation: true. NOT compatible with GKE Sandbox.
+K8S_EXECUTION_MODE=agent
+# K8S_EXECUTOR_PORT=9090  # Port for the executor-agent HTTP server (agent mode only)
+
+# Sidecar image — must match the execution mode:
+#   agent mode:   aronmuon/kubecoderun-sidecar-agent:latest   (default)
+#   nsenter mode: aronmuon/kubecoderun-sidecar-nsenter:latest
+# K8S_SIDECAR_IMAGE=aronmuon/kubecoderun-sidecar-agent:latest
+
+# Image pull policy for execution pods (Always, IfNotPresent, Never)
+# K8S_IMAGE_PULL_POLICY=Always
+
+# Image pull secrets for private container registries (comma-separated secret names)
+# These Kubernetes secrets must already exist in the execution namespace.
+# Leave empty or unset if not using private registries.
+# K8S_IMAGE_PULL_SECRETS=my-registry-secret,another-secret
+
+# GKE Sandbox (gVisor) Configuration
+# Requires K8S_EXECUTION_MODE=agent (nsenter is incompatible with gVisor)
+# GKE_SANDBOX_ENABLED=false
+# GKE_SANDBOX_RUNTIME_CLASS=gvisor
+# GKE_SANDBOX_NODE_SELECTOR={}
+# GKE_SANDBOX_CUSTOM_TOLERATIONS=[]
 
 # WAN Network Access Configuration
 # When enabled, execution containers can access the public internet

--- a/.github/workflows/docker-build-reusable.yml
+++ b/.github/workflows/docker-build-reusable.yml
@@ -29,6 +29,11 @@ on:
         type: string
         default: ''
         description: 'Version string to pass as VERSION build arg (for hatch-vcs)'
+      build_target:
+        required: false
+        type: string
+        default: ''
+        description: 'Docker build target (e.g., sidecar-agent, sidecar-nsenter). Empty = default target.'
 
 jobs:
   build:
@@ -74,6 +79,7 @@ jobs:
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.build_target || '' }}
           push: true
           tags: ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-${{ steps.vars.outputs.tag }}
           platforms: ${{ matrix.platform }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,9 +145,26 @@ jobs:
     uses: ./.github/workflows/docker-build-reusable.yml
     secrets: inherit
     with:
-      image_name: kubecoderun-sidecar
+      image_name: kubecoderun-sidecar-agent
       dockerfile: docker/sidecar/Dockerfile
       context: docker/sidecar
+      build_target: sidecar-agent
+      image_tag: ${{ needs.changes.outputs.image_tag }}
+      is_release: ${{ needs.changes.outputs.is_release == 'true' }}
+      version: ${{ needs.changes.outputs.version }}
+
+  sidecar-nsenter:
+    needs: changes
+    if: |
+      needs.changes.outputs.is_cross_repo_pr != 'true' &&
+      (needs.changes.outputs.sidecar == 'true' || needs.changes.outputs.force_all == 'true')
+    uses: ./.github/workflows/docker-build-reusable.yml
+    secrets: inherit
+    with:
+      image_name: kubecoderun-sidecar-nsenter
+      dockerfile: docker/sidecar/Dockerfile
+      context: docker/sidecar
+      build_target: sidecar-nsenter
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
       version: ${{ needs.changes.outputs.version }}
@@ -344,7 +361,7 @@ jobs:
     uses: ./.github/workflows/docker-retag-reusable.yml
     secrets: inherit
     with:
-      image_name: kubecoderun-sidecar
+      image_name: kubecoderun-sidecar-agent
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,5 @@ config/local.py
 
 # Hatch auto-generated version file
 _version.py
+
+.pdm-python

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -1,38 +1,50 @@
 # syntax=docker/dockerfile:1
-# KubeCodeRun HTTP sidecar with Docker Hardened Images.
+# KubeCodeRun HTTP Sidecar — Multi-target Dockerfile.
+#
+# Produces two distinct container images via Docker build targets:
+#
+#   docker build --target sidecar-agent   → kubecoderun-sidecar-agent (default)
+#   docker build --target sidecar-nsenter → kubecoderun-sidecar-nsenter
+#
+# sidecar-agent (default):
+#   - Contains the executor-agent Go binary (copied to main container via init container)
+#   - No nsenter, no setcap, no capabilities, no privilege escalation
+#   - Compatible with GKE Sandbox (gVisor) and restricted Pod Security Standards
+#
+# sidecar-nsenter (legacy):
+#   - Contains nsenter with file capabilities (setcap) for namespace entry
+#   - Requires shareProcessNamespace, SYS_PTRACE/SYS_ADMIN/SYS_CHROOT capabilities,
+#     and allowPrivilegeEscalation: true in the pod spec
+#   - For clusters that do not support agent mode or need legacy behavior
 
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
 
 ################################
-# Builder stage - install Python dependencies and runtime tools
+# Executor agent build stage — statically compiled Go binary.
+# This binary runs in the main (language) container via init container copy,
+# providing HTTP-based code execution without nsenter.
 ################################
-FROM dhi.io/python:3.13-debian13-dev AS builder
+FROM golang:1.26-alpine AS agent-builder
+
+WORKDIR /build
+COPY executor-agent/ .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o /opt/executor-agent .
+
+################################
+# Python builder (common) — install Python dependencies and app code.
+# Used by both agent and nsenter targets.
+################################
+FROM dhi.io/python:3.13-debian13-dev AS builder-common
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install runtime dependencies and set up nsenter with file capabilities
-# - util-linux: provides nsenter for entering container namespaces
-# - libcap2-bin: provides setcap for setting file capabilities
-# Create both arch lib dirs to ensure COPY works on either architecture
+# Create data directory and arch lib dirs (for COPY compatibility)
 RUN mkdir -p /lib/x86_64-linux-gnu /lib/aarch64-linux-gnu && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    util-linux \
-    libcap2-bin \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /mnt/data && chown 65532:65532 /mnt/data
-
-# Add file capabilities to nsenter binary so non-root users can use it
-# - cap_sys_ptrace: access /proc/<pid>/ns/ of other processes
-# - cap_sys_admin: call setns() to enter namespaces
-# - cap_sys_chroot: required for mount namespace operations
-RUN setcap 'cap_sys_ptrace,cap_sys_admin,cap_sys_chroot+eip' /usr/bin/nsenter
+    mkdir -p /mnt/data && chown 65532:65532 /mnt/data
 
 WORKDIR /app
 
@@ -45,41 +57,47 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY main.py .
 
 ################################
-# Final stage - minimal runtime image
+# nsenter builder — extends common builder with nsenter + file capabilities.
+# Only needed for the nsenter sidecar target.
 ################################
-FROM dhi.io/python:3.13-debian13 AS final
+FROM builder-common AS builder-nsenter
+
+# Install nsenter (util-linux) and setcap (libcap2-bin)
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    util-linux \
+    libcap2-bin \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add file capabilities to nsenter binary so non-root users can use it
+# - cap_sys_ptrace: access /proc/<pid>/ns/ of other processes
+# - cap_sys_admin: call setns() to enter namespaces
+# - cap_sys_chroot: required for mount namespace operations
+RUN setcap 'cap_sys_ptrace,cap_sys_admin,cap_sys_chroot+eip' /usr/bin/nsenter
+
+
+################################
+# Common runtime base — shared by both final targets.
+# Contains Python runtime, sidecar app, and common configuration.
+################################
+FROM dhi.io/python:3.13-debian13 AS runtime-base
 
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
 
-LABEL org.opencontainers.image.title="KubeCodeRun Sidecar" \
-      org.opencontainers.image.description="HTTP sidecar for executing code in Kubernetes pods via nsenter" \
-      org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.created="${BUILD_DATE}" \
-      org.opencontainers.image.revision="${VCS_REF}"
-
-# Copy nsenter with file capabilities from builder
-COPY --from=builder /usr/bin/nsenter /usr/bin/
-
-# Copy shared libraries needed by nsenter (libselinux, libpcre2) for both architectures
-# Note: Only one arch directory will have content depending on build platform
-COPY --from=builder /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
-COPY --from=builder /lib/aarch64-linux-gnu /lib/aarch64-linux-gnu
-
 # Copy installed Python packages from builder
 # DHI Python is installed in /opt/python, not /usr/local
-COPY --from=builder /opt/python/lib/python3.13/site-packages /opt/python/lib/python3.13/site-packages
-COPY --from=builder /opt/python/bin /opt/python/bin
-
-# Copy /usr/bin/env for execution patterns, sleep for CMD
-COPY --from=builder /usr/bin/env /usr/bin/sleep /usr/bin/
+COPY --from=builder-common /opt/python/lib/python3.13/site-packages /opt/python/lib/python3.13/site-packages
+COPY --from=builder-common /opt/python/bin /opt/python/bin
 
 # Copy data directory with correct ownership (DHI uses UID 65532)
-COPY --from=builder /mnt/data /mnt/data
+COPY --from=builder-common /mnt/data /mnt/data
 
 # Copy application code
-COPY --from=builder /app /app
+COPY --from=builder-common /app /app
 
 WORKDIR /app
 
@@ -102,15 +120,80 @@ ENV VERSION=${VERSION} \
     MAX_EXECUTION_TIME=120 \
     PYTHONUNBUFFERED=1
 
-# Kubernetes pod spec still requires:
-# - shareProcessNamespace: true (so sidecar can see main container's processes)
-# - securityContext.capabilities.add: ["SYS_PTRACE", "SYS_ADMIN", "SYS_CHROOT"]
-#   (to allow the bounding set to include these caps)
-# - securityContext.allowPrivilegeEscalation: true
-#   (required for file capabilities to be honored)
-
 # DHI images run as non-root (UID 65532) by default
-# File capabilities on nsenter allow this user to use nsenter with required privileges
-
-# Run sidecar
 CMD ["python", "main.py"]
+
+
+################################
+# TARGET: sidecar-agent (default)
+#
+# Agent mode sidecar — the recommended execution mode.
+# Contains the executor-agent Go binary for init-container distribution.
+# No nsenter, no capabilities, no privilege escalation needed.
+#
+# Kubernetes pod spec (agent mode):
+#   - No shareProcessNamespace needed
+#   - No capabilities needed (all dropped)
+#   - allowPrivilegeEscalation: false for all containers
+#   - Init container copies /opt/executor-agent to shared volume
+#   - Main container runs executor-agent instead of sleep infinity
+#   - Compatible with GKE Sandbox (gVisor) and restricted Pod Security Standards
+#
+# Build: docker build --target sidecar-agent -t kubecoderun-sidecar-agent .
+################################
+FROM runtime-base AS sidecar-agent
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="KubeCodeRun Sidecar (Agent)" \
+      org.opencontainers.image.description="HTTP sidecar for executing code in Kubernetes pods via executor agent" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+# Copy executor agent binary (distributed to main container via init container)
+COPY --from=agent-builder /opt/executor-agent /opt/executor-agent
+
+ENV EXECUTION_MODE=agent
+
+
+################################
+# TARGET: sidecar-nsenter (legacy)
+#
+# nsenter mode sidecar — for backward compatibility.
+# Contains nsenter with file capabilities for namespace entry.
+#
+# Kubernetes pod spec (nsenter mode):
+#   - shareProcessNamespace: true (so sidecar can see main container's processes)
+#   - securityContext.capabilities.add: ["SYS_PTRACE", "SYS_ADMIN", "SYS_CHROOT"]
+#   - securityContext.allowPrivilegeEscalation: true
+#     (required for file capabilities to be honored)
+#
+# Build: docker build --target sidecar-nsenter -t kubecoderun-sidecar-nsenter .
+################################
+FROM runtime-base AS sidecar-nsenter
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="KubeCodeRun Sidecar (nsenter)" \
+      org.opencontainers.image.description="HTTP sidecar for executing code in Kubernetes pods via nsenter" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+# Copy nsenter with file capabilities from nsenter builder
+COPY --from=builder-nsenter /usr/bin/nsenter /usr/bin/
+
+# Copy /usr/bin/env from builder — nsenter mode uses /usr/bin/env -i for clean execution
+COPY --from=builder-common /usr/bin/env /usr/bin/env
+
+# Copy shared libraries needed by nsenter (libselinux, libpcre2) for both architectures
+# Note: Only one arch directory will have content depending on build platform
+COPY --from=builder-nsenter /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+COPY --from=builder-nsenter /lib/aarch64-linux-gnu /lib/aarch64-linux-gnu
+
+ENV EXECUTION_MODE=nsenter

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -26,7 +26,7 @@ ARG VCS_REF
 # This binary runs in the main (language) container via init container copy,
 # providing HTTP-based code execution without nsenter.
 ################################
-FROM golang:1.26-alpine AS agent-builder
+FROM dhi.io/golang:1.26-debian13-dev AS agent-builder
 
 WORKDIR /build
 COPY executor-agent/ .

--- a/docker/sidecar/executor-agent/go.mod
+++ b/docker/sidecar/executor-agent/go.mod
@@ -1,0 +1,3 @@
+module executor-agent
+
+go 1.26

--- a/docker/sidecar/executor-agent/main.go
+++ b/docker/sidecar/executor-agent/main.go
@@ -1,0 +1,253 @@
+// Executor Agent - Lightweight HTTP server for code execution in Kubernetes pods.
+//
+// This binary runs inside the main (language) container and provides an HTTP API
+// that the sidecar uses to execute code. It replaces the nsenter-based approach,
+// enabling execution without any Linux capabilities or privilege escalation.
+//
+// Architecture:
+//   - Listens on localhost (pod-internal only) on a configurable port (default: 9090)
+//   - Receives execution requests from the sidecar via HTTP
+//   - Spawns subprocesses using the container's inherited environment (PATH, HOME, etc.)
+//   - Returns stdout, stderr, exit code, and execution time
+//
+// The agent inherits its environment from the container's ENTRYPOINT (env -i PATH=... HOME=...),
+// ensuring subprocesses run with the exact same sanitized environment as the language runtime.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultPort   = 9090
+	maxOutputSize = 1048576  // 1MB - matches sidecar's MAX_OUTPUT_SIZE
+	maxBodySize   = 10485760 // 10MB
+)
+
+// ExecuteRequest is the JSON request body for /execute.
+type ExecuteRequest struct {
+	Command    []string          `json:"command"`
+	Timeout    int               `json:"timeout"`
+	WorkingDir string            `json:"working_dir"`
+	Env        map[string]string `json:"env,omitempty"`
+}
+
+// ExecuteResponse is the JSON response body for /execute.
+type ExecuteResponse struct {
+	ExitCode        int    `json:"exit_code"`
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	ExecutionTimeMs int64  `json:"execution_time_ms"`
+}
+
+func handleExecute(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, ExecuteResponse{
+			ExitCode: 1, Stderr: "Failed to read request body",
+		})
+		return
+	}
+
+	var req ExecuteRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, ExecuteResponse{
+			ExitCode: 1, Stderr: fmt.Sprintf("Invalid JSON: %v", err),
+		})
+		return
+	}
+
+	if len(req.Command) == 0 {
+		writeJSON(w, http.StatusBadRequest, ExecuteResponse{
+			ExitCode: 1, Stderr: "No command specified",
+		})
+		return
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = 30
+	}
+
+	workingDir := req.WorkingDir
+	if workingDir == "" {
+		workingDir = "/mnt/data"
+	}
+
+	// Validate that working directory is within the safe /mnt/data directory.
+	// Use filepath.Clean + exact-prefix check to prevent traversal to e.g. /mnt/data2.
+	absDir, err := filepath.Abs(workingDir)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, ExecuteResponse{
+			ExitCode: 1, Stderr: fmt.Sprintf("Invalid working directory: %v", err),
+		})
+		return
+	}
+	absDir = filepath.Clean(absDir)
+	if absDir != "/mnt/data" && !strings.HasPrefix(absDir, "/mnt/data/") {
+		writeJSON(w, http.StatusBadRequest, ExecuteResponse{
+			ExitCode: 1, Stderr: fmt.Sprintf("Invalid working directory: must be within /mnt/data, got %q", workingDir),
+		})
+		return
+	}
+	workingDir = absDir
+
+	fmt.Fprintf(os.Stdout, "[executor-agent] cmd=%v timeout=%ds dir=%s\n",
+		req.Command, timeout, workingDir)
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, req.Command[0], req.Command[1:]...)
+	cmd.Dir = workingDir
+
+	// Inherit the current process environment (from container's ENTRYPOINT env -i).
+	// Merge request-provided env overrides by replacing existing keys (so the
+	// override actually takes effect regardless of runtime first/last-wins semantics).
+	if len(req.Env) > 0 {
+		env := os.Environ()
+		for k, v := range req.Env {
+			prefix := k + "="
+			found := false
+			for i, e := range env {
+				if strings.HasPrefix(e, prefix) {
+					env[i] = prefix + v
+					found = true
+					break
+				}
+			}
+			if !found {
+				env = append(env, prefix+v)
+			}
+		}
+		cmd.Env = env
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	elapsed := time.Since(start).Milliseconds()
+
+	exitCode := 0
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			fmt.Fprintf(os.Stdout, "[executor-agent] TIMEOUT after %ds\n", timeout)
+			writeJSON(w, http.StatusOK, ExecuteResponse{
+				ExitCode:        124,
+				Stdout:          "",
+				Stderr:          fmt.Sprintf("Execution timed out after %d seconds", timeout),
+				ExecutionTimeMs: elapsed,
+			})
+			return
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			writeJSON(w, http.StatusOK, ExecuteResponse{
+				ExitCode:        1,
+				Stdout:          "",
+				Stderr:          fmt.Sprintf("Failed to execute command: %v", err),
+				ExecutionTimeMs: elapsed,
+			})
+			return
+		}
+	}
+
+	stdoutStr := truncate(stdout.String(), maxOutputSize)
+	stderrStr := truncate(stderr.String(), maxOutputSize)
+
+	fmt.Fprintf(os.Stdout, "[executor-agent] exit=%d stdout=%d stderr=%d time=%dms\n",
+		exitCode, len(stdoutStr), len(stderrStr), elapsed)
+
+	writeJSON(w, http.StatusOK, ExecuteResponse{
+		ExitCode:        exitCode,
+		Stdout:          stdoutStr,
+		Stderr:          stderrStr,
+		ExecutionTimeMs: elapsed,
+	})
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "healthy"})
+}
+
+func handleReady(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+}
+
+func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data) //nolint:errcheck
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
+func main() {
+	port := defaultPort
+
+	// Parse --port flag from CLI args
+	for i := 1; i < len(os.Args)-1; i++ {
+		if os.Args[i] == "--port" {
+			if p, err := strconv.Atoi(os.Args[i+1]); err == nil {
+				port = p
+			}
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/execute", handleExecute)
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/ready", handleReady)
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf("127.0.0.1:%d", port),
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 300 * time.Second,
+	}
+
+	// Graceful shutdown on SIGTERM/SIGINT
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		fmt.Fprintln(os.Stdout, "[executor-agent] Shutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		server.Shutdown(ctx) //nolint:errcheck
+	}()
+
+	fmt.Fprintf(os.Stdout, "[executor-agent] Listening on 127.0.0.1:%d\n", port)
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		fmt.Fprintf(os.Stderr, "[executor-agent] Server error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docker/sidecar/main.py
+++ b/docker/sidecar/main.py
@@ -115,6 +115,36 @@ def validate_path_within_working_dir(path: str) -> Path:
         raise HTTPException(status_code=400, detail="Invalid path")
 
 
+def _validate_working_dir(working_dir: str) -> str:
+    """Validate that working_dir is within WORKING_DIR before any file writes.
+
+    Prevents a caller from directing code-file writes outside /mnt/data by
+    supplying a crafted working_dir (e.g. /etc, /proc).  Called at the start
+    of every execute path before _write_code_file / spawning processes.
+
+    Args:
+        working_dir: The user-supplied working directory string.
+
+    Returns:
+        The resolved, safe working directory string.
+
+    Raises:
+        ValueError: If working_dir escapes WORKING_DIR.
+    """
+    try:
+        resolved = Path(working_dir).resolve()
+        working_path = Path(WORKING_DIR).resolve()
+        if not resolved.is_relative_to(working_path):
+            raise ValueError(
+                f"working_dir '{working_dir}' is outside WORKING_DIR '{WORKING_DIR}'"
+            )
+        return str(resolved)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Invalid working_dir '{working_dir}': {exc}") from exc
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan handler."""
@@ -354,10 +384,22 @@ async def execute_via_agent(request: ExecuteRequest) -> ExecuteResponse:
     """
     start_time = time.perf_counter()
 
+    # Validate working_dir before any file writes to prevent path-traversal
+    # (e.g. a caller supplying /etc would write code files outside /mnt/data)
+    try:
+        safe_working_dir = _validate_working_dir(request.working_dir)
+    except ValueError as exc:
+        return ExecuteResponse(
+            exit_code=1,
+            stdout="",
+            stderr=str(exc),
+            execution_time_ms=0,
+        )
+
     try:
         # Write code to a temp file and get the bare command (no env -i wrapper)
         cmd, temp_file = get_language_command_bare(
-            LANGUAGE, request.code, request.working_dir
+            LANGUAGE, request.code, safe_working_dir
         )
         if not cmd:
             return ExecuteResponse(
@@ -386,7 +428,7 @@ async def execute_via_agent(request: ExecuteRequest) -> ExecuteResponse:
                 json={
                     "command": cmd,
                     "timeout": request.timeout,
-                    "working_dir": request.working_dir,
+                    "working_dir": safe_working_dir,
                     "env": env_overrides if env_overrides else None,
                 },
                 timeout=request.timeout + 10,  # Extra margin for HTTP overhead
@@ -440,6 +482,17 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
     """
     start_time = time.perf_counter()
 
+    # Validate working_dir before any file writes to prevent path-traversal
+    try:
+        safe_working_dir = _validate_working_dir(request.working_dir)
+    except ValueError as exc:
+        return ExecuteResponse(
+            exit_code=1,
+            stdout="",
+            stderr=str(exc),
+            execution_time_ms=0,
+        )
+
     try:
         # Find the main container's PID
         main_pid = find_main_container_pid()
@@ -457,7 +510,7 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
 
         # Get the command for this language (this writes code to a temp file)
         cmd, temp_file = get_language_command(
-            LANGUAGE, request.code, request.working_dir, container_env
+            LANGUAGE, request.code, safe_working_dir, container_env
         )
         if not cmd:
             return ExecuteResponse(
@@ -481,7 +534,7 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
     # Note: The spawned process runs in the SIDECAR's cgroup, not the main container's.
     # This means memory-heavy executions count against sidecar's limit.
     # Ensure sidecar has adequate memory for the target language.
-    wd_args = [f"--wdns={request.working_dir}"]
+    wd_args = [f"--wdns={safe_working_dir}"]
     nsenter_cmd = [
         "nsenter",
         "-t", str(main_pid),
@@ -503,7 +556,7 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
             *nsenter_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=request.working_dir,
+            cwd=safe_working_dir,
         )
         print(f"[EXECUTE] Subprocess created, pid={proc.pid}, waiting for completion (timeout={request.timeout}s)...", flush=True)
 

--- a/docker/sidecar/main.py
+++ b/docker/sidecar/main.py
@@ -48,8 +48,10 @@ EXECUTION_MODE = os.getenv("EXECUTION_MODE", "agent")
 # Executor port (used in agent mode for the executor agent HTTP server)
 EXECUTOR_PORT = int(os.getenv("EXECUTOR_PORT", "9090"))
 
+
 class ExecuteRequest(BaseModel):
     """Request to execute code."""
+
     code: str
     timeout: int = Field(default=30, ge=1, le=MAX_EXECUTION_TIME)
     working_dir: str = Field(default=WORKING_DIR)
@@ -59,6 +61,7 @@ class ExecuteRequest(BaseModel):
 
 class ExecuteResponse(BaseModel):
     """Response from code execution."""
+
     exit_code: int
     stdout: str
     stderr: str
@@ -69,6 +72,7 @@ class ExecuteResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     """Health check response."""
+
     status: str
     language: str
     working_dir: str
@@ -77,6 +81,7 @@ class HealthResponse(BaseModel):
 
 class FileInfo(BaseModel):
     """File information."""
+
     name: str
     path: str
     size: int
@@ -135,9 +140,7 @@ def _validate_working_dir(working_dir: str) -> str:
         resolved = Path(working_dir).resolve()
         working_path = Path(WORKING_DIR).resolve()
         if not resolved.is_relative_to(working_path):
-            raise ValueError(
-                f"working_dir '{working_dir}' is outside WORKING_DIR '{WORKING_DIR}'"
-            )
+            raise ValueError(f"working_dir '{working_dir}' is outside WORKING_DIR '{WORKING_DIR}'")
         return str(resolved)
     except ValueError:
         raise
@@ -251,7 +254,7 @@ def apply_network_isolation_overrides(env: dict[str, str], language: str) -> dic
     if language in ("go",):
         env["GOPROXY"] = "off"
         env["GOSUMDB"] = "off"
-        print(f"[EXECUTE] Network isolation: overriding GOPROXY=off, GOSUMDB=off", flush=True)
+        print("[EXECUTE] Network isolation: overriding GOPROXY=off, GOSUMDB=off", flush=True)
 
     # Future: Add overrides for other languages as needed
     # - Rust: CARGO_NET_OFFLINE=true
@@ -347,7 +350,9 @@ def get_language_command(
 
 
 def get_language_command_bare(
-    language: str, code: str, working_dir: str,
+    language: str,
+    code: str,
+    working_dir: str,
 ) -> tuple[list[str], Path | None]:
     """Get the bare command to execute code for a given language (agent mode).
 
@@ -371,7 +376,7 @@ def get_network_isolation_overrides(language: str) -> dict[str, str]:
     if language in ("go",):
         overrides["GOPROXY"] = "off"
         overrides["GOSUMDB"] = "off"
-        print(f"[EXECUTE] Network isolation: overriding GOPROXY=off, GOSUMDB=off", flush=True)
+        print("[EXECUTE] Network isolation: overriding GOPROXY=off, GOSUMDB=off", flush=True)
     return overrides
 
 
@@ -398,9 +403,7 @@ async def execute_via_agent(request: ExecuteRequest) -> ExecuteResponse:
 
     try:
         # Write code to a temp file and get the bare command (no env -i wrapper)
-        cmd, temp_file = get_language_command_bare(
-            LANGUAGE, request.code, safe_working_dir
-        )
+        cmd, temp_file = get_language_command_bare(LANGUAGE, request.code, safe_working_dir)
         if not cmd:
             return ExecuteResponse(
                 exit_code=1,
@@ -462,7 +465,7 @@ async def execute_via_agent(request: ExecuteRequest) -> ExecuteResponse:
             exit_code=1,
             stdout="",
             stderr=f"Cannot connect to executor agent at 127.0.0.1:{EXECUTOR_PORT}. "
-                   f"Ensure the main container is running the executor agent.",
+            f"Ensure the main container is running the executor agent.",
             execution_time_ms=int((time.perf_counter() - start_time) * 1000),
         )
     except Exception as e:
@@ -509,9 +512,7 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
         container_env = apply_network_isolation_overrides(container_env, LANGUAGE)
 
         # Get the command for this language (this writes code to a temp file)
-        cmd, temp_file = get_language_command(
-            LANGUAGE, request.code, safe_working_dir, container_env
-        )
+        cmd, temp_file = get_language_command(LANGUAGE, request.code, safe_working_dir, container_env)
         if not cmd:
             return ExecuteResponse(
                 exit_code=1,
@@ -537,7 +538,8 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
     wd_args = [f"--wdns={safe_working_dir}"]
     nsenter_cmd = [
         "nsenter",
-        "-t", str(main_pid),
+        "-t",
+        str(main_pid),
         "-m",  # Mount namespace - access main container's filesystem
         *wd_args,
         "--",
@@ -548,17 +550,23 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
     print(f"[EXECUTE] container_env PATH={container_env.get('PATH', 'NOT SET')}", flush=True)
     print(f"[EXECUTE] nsenter_cmd={nsenter_cmd}", flush=True)
     if temp_file:
-        print(f"[EXECUTE] code_file={temp_file}, exists={temp_file.exists()}, size={temp_file.stat().st_size if temp_file.exists() else 0}", flush=True)
+        print(
+            f"[EXECUTE] code_file={temp_file}, exists={temp_file.exists()}, size={temp_file.stat().st_size if temp_file.exists() else 0}",
+            flush=True,
+        )
 
     try:
-        print(f"[EXECUTE] Creating subprocess...", flush=True)
+        print("[EXECUTE] Creating subprocess...", flush=True)
         proc = await asyncio.create_subprocess_exec(
             *nsenter_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=safe_working_dir,
         )
-        print(f"[EXECUTE] Subprocess created, pid={proc.pid}, waiting for completion (timeout={request.timeout}s)...", flush=True)
+        print(
+            f"[EXECUTE] Subprocess created, pid={proc.pid}, waiting for completion (timeout={request.timeout}s)...",
+            flush=True,
+        )
 
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -582,7 +590,10 @@ async def execute_via_nsenter(request: ExecuteRequest) -> ExecuteResponse:
         stderr_str = stderr.decode("utf-8", errors="replace")[:MAX_OUTPUT_SIZE]
 
         # Debug logging
-        print(f"[EXECUTE] exit_code={proc.returncode}, stdout_len={len(stdout_str)}, stderr_len={len(stderr_str)}", flush=True)
+        print(
+            f"[EXECUTE] exit_code={proc.returncode}, stdout_len={len(stdout_str)}, stderr_len={len(stderr_str)}",
+            flush=True,
+        )
         if stdout_str:
             print(f"[EXECUTE] stdout preview: {stdout_str[:500]!r}", flush=True)
         if stderr_str:
@@ -690,11 +701,13 @@ async def upload_files(files: list[UploadFile] = File(...)):
             content = await file.read()
             f.write(content)
 
-        uploaded.append(FileInfo(
-            name=safe_name,
-            path=str(dest_path),
-            size=len(content),
-        ))
+        uploaded.append(
+            FileInfo(
+                name=safe_name,
+                path=str(dest_path),
+                size=len(content),
+            )
+        )
 
     return {"uploaded": [f.model_dump() for f in uploaded]}
 
@@ -708,11 +721,13 @@ async def list_files():
 
     files = []
     for item in working_path.iterdir():
-        files.append(FileInfo(
-            name=item.name,
-            path=item.name,
-            size=item.stat().st_size if item.is_file() else 0,
-        ))
+        files.append(
+            FileInfo(
+                name=item.name,
+                path=item.name,
+                size=item.stat().st_size if item.is_file() else 0,
+            )
+        )
     return {"files": [f.model_dump() for f in files]}
 
 
@@ -729,11 +744,13 @@ async def download_file(path: str):
         # List directory contents
         files = []
         for item in file_path.iterdir():
-            files.append(FileInfo(
-                name=item.name,
-                path=str(item.relative_to(working_path)),
-                size=item.stat().st_size if item.is_file() else 0,
-            ))
+            files.append(
+                FileInfo(
+                    name=item.name,
+                    path=str(item.relative_to(working_path)),
+                    size=item.stat().st_size if item.is_file() else 0,
+                )
+            )
         return {"files": [f.model_dump() for f in files]}
 
     return FileResponse(file_path)

--- a/helm-deployments/kubecoderun/templates/_helpers.tpl
+++ b/helm-deployments/kubecoderun/templates/_helpers.tpl
@@ -78,19 +78,21 @@ Execution namespace
 {{- end }}
 
 {{/*
-Redis URL
+Redis URL — honours TLS setting to switch between redis:// and rediss://
 */}}
 {{- define "kubecoderun.redisUrl" -}}
 {{- if .Values.redis.url }}
 {{- .Values.redis.url }}
 {{- else if .Values.redis.host }}
+{{- $scheme := ternary "rediss" "redis" .Values.redis.tls.enabled }}
 {{- if .Values.redis.password }}
-{{- printf "redis://:%s@%s:%d/%d" .Values.redis.password .Values.redis.host (int .Values.redis.port) (int .Values.redis.db) }}
+{{- printf "%s://:%s@%s:%d/%d" $scheme .Values.redis.password .Values.redis.host (int .Values.redis.port) (int .Values.redis.db) }}
 {{- else }}
-{{- printf "redis://%s:%d/%d" .Values.redis.host (int .Values.redis.port) (int .Values.redis.db) }}
+{{- printf "%s://%s:%d/%d" $scheme .Values.redis.host (int .Values.redis.port) (int .Values.redis.db) }}
 {{- end }}
 {{- else }}
-{{- "redis://redis:6379/0" }}
+{{- $scheme := ternary "rediss" "redis" .Values.redis.tls.enabled }}
+{{- printf "%s://redis:6379/0" $scheme }}
 {{- end }}
 {{- end }}
 

--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -36,14 +36,31 @@ data:
   K8S_IMAGE_REGISTRY: {{ .Values.execution.imageRegistry | quote }}
   K8S_IMAGE_TAG: {{ $imageTag | quote }}
   K8S_IMAGE_PULL_POLICY: {{ .Values.execution.imagePullPolicy | quote }}
+  {{- if .Values.execution.imagePullSecrets }}
+  K8S_IMAGE_PULL_SECRETS: {{ join "," (pluck "name" .Values.execution.imagePullSecrets) | quote }}
+  {{- else }}
+  K8S_IMAGE_PULL_SECRETS: ""
+  {{- end }}
   K8S_CPU_LIMIT: {{ .Values.execution.resources.limits.cpu | quote }}
   K8S_MEMORY_LIMIT: {{ .Values.execution.resources.limits.memory | quote }}
   K8S_CPU_REQUEST: {{ .Values.execution.resources.requests.cpu | quote }}
   K8S_MEMORY_REQUEST: {{ .Values.execution.resources.requests.memory | quote }}
   K8S_RUN_AS_USER: {{ .Values.execution.securityContext.runAsUser | quote }}
+  K8S_EXECUTION_MODE: {{ .Values.execution.executionMode | quote }}
+  K8S_EXECUTOR_PORT: {{ .Values.execution.executorPort | quote }}
   K8S_SECCOMP_PROFILE_TYPE: {{ .Values.execution.securityContext.seccompProfile.type | quote }}
   K8S_JOB_TTL_SECONDS: {{ .Values.execution.jobs.ttlSecondsAfterFinished | quote }}
   K8S_JOB_DEADLINE_SECONDS: {{ .Values.execution.jobs.activeDeadlineSeconds | quote }}
+
+  # GKE Sandbox Configuration
+  GKE_SANDBOX_ENABLED: {{ .Values.execution.gkeSandbox.enabled | quote }}
+  GKE_SANDBOX_RUNTIME_CLASS: {{ .Values.execution.gkeSandbox.runtimeClassName | quote }}
+  {{- if .Values.execution.gkeSandbox.nodeSelector }}
+  GKE_SANDBOX_NODE_SELECTOR: {{ .Values.execution.gkeSandbox.nodeSelector | toJson | quote }}
+  {{- end }}
+  {{- if .Values.execution.gkeSandbox.customTolerations }}
+  GKE_SANDBOX_CUSTOM_TOLERATIONS: {{ .Values.execution.gkeSandbox.customTolerations | toJson | quote }}
+  {{- end }}
 
   # Pod Lifecycle
   POD_TTL_MINUTES: {{ .Values.execution.podTtlMinutes | quote }}
@@ -302,10 +319,41 @@ data:
   WAN_NETWORK_NAME: {{ .Values.network.wan.networkName | quote }}
   WAN_DNS_SERVERS: {{ .Values.network.wan.dnsServers | toJson | quote }}
 
-  # Redis Advanced Configuration
+  # Redis Configuration
+  REDIS_MODE: {{ .Values.redis.mode | quote }}
+  {{- if .Values.redis.host }}
+  REDIS_HOST: {{ .Values.redis.host | quote }}
+  {{- end }}
+  REDIS_PORT: {{ .Values.redis.port | quote }}
+  REDIS_DB: {{ .Values.redis.db | quote }}
   REDIS_MAX_CONNECTIONS: {{ .Values.redis.maxConnections | quote }}
   REDIS_SOCKET_TIMEOUT: {{ .Values.redis.socketTimeout | quote }}
   REDIS_SOCKET_CONNECT_TIMEOUT: {{ .Values.redis.socketConnectTimeout | quote }}
+  {{- if .Values.redis.keyPrefix }}
+  REDIS_KEY_PREFIX: {{ .Values.redis.keyPrefix | quote }}
+  {{- end }}
+  {{- if .Values.redis.clusterNodes }}
+  REDIS_CLUSTER_NODES: {{ .Values.redis.clusterNodes | quote }}
+  {{- end }}
+  {{- if .Values.redis.sentinelNodes }}
+  REDIS_SENTINEL_NODES: {{ .Values.redis.sentinelNodes | quote }}
+  {{- end }}
+  REDIS_SENTINEL_MASTER: {{ .Values.redis.sentinelMaster | quote }}
+  {{- if .Values.redis.sentinelPassword }}
+  REDIS_SENTINEL_PASSWORD: {{ .Values.redis.sentinelPassword | quote }}
+  {{- end }}
+  REDIS_TLS_ENABLED: {{ .Values.redis.tls.enabled | quote }}
+  {{- if .Values.redis.tls.caCertFile }}
+  REDIS_TLS_CA_CERT_FILE: {{ .Values.redis.tls.caCertFile | quote }}
+  {{- end }}
+  {{- if .Values.redis.tls.certFile }}
+  REDIS_TLS_CERT_FILE: {{ .Values.redis.tls.certFile | quote }}
+  {{- end }}
+  {{- if .Values.redis.tls.keyFile }}
+  REDIS_TLS_KEY_FILE: {{ .Values.redis.tls.keyFile | quote }}
+  {{- end }}
+  REDIS_TLS_INSECURE: {{ .Values.redis.tls.insecure | quote }}
+  REDIS_TLS_CHECK_HOSTNAME: {{ .Values.redis.tls.checkHostname | quote }}
 
   # MinIO/S3 Configuration
   {{- if not .Values.secretsStore.enabled }}

--- a/helm-deployments/kubecoderun/templates/secret.yaml
+++ b/helm-deployments/kubecoderun/templates/secret.yaml
@@ -20,8 +20,11 @@ stringData:
   {{- end }}
   {{- end }}
   {{- if not .Values.redis.existingSecret }}
-  # Redis URL
+  # Redis URL (standalone mode) and password (all modes)
   REDIS_URL: {{ include "kubecoderun.redisUrl" . | quote }}
+  {{- if .Values.redis.password }}
+  REDIS_PASSWORD: {{ .Values.redis.password | quote }}
+  {{- end }}
   {{- end }}
   {{- if and (not .Values.minio.existingSecret) (not .Values.minio.useIAM) }}
   # S3-Compatible Storage Credentials (Garage/MinIO/S3)

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -99,6 +99,10 @@ redis:
   # When set, the url/host/port/password/db fields below are ignored
   # Expected secret key: REDIS_URL (full connection string)
   existingSecret: ""
+
+  # Deployment mode: standalone (default), cluster, or sentinel
+  mode: "standalone"
+
   # External Redis URL (required unless existingSecret is set)
   url: "redis://redis:6379/0"
   # Or specify individual fields
@@ -110,6 +114,35 @@ redis:
   maxConnections: 20
   socketTimeout: 5
   socketConnectTimeout: 5
+
+  # Optional key prefix prepended to every Redis key.
+  # Useful when sharing a Redis instance across environments.
+  keyPrefix: ""
+
+  # Redis Cluster mode (mode: cluster)
+  # Comma-separated host:port pairs for cluster startup nodes
+  clusterNodes: ""
+
+  # Redis Sentinel mode (mode: sentinel)
+  # Comma-separated host:port pairs for sentinel instances
+  sentinelNodes: ""
+  sentinelMaster: "mymaster"
+  sentinelPassword: ""
+
+  # TLS/SSL settings (all modes)
+  tls:
+    enabled: false
+    # Path to CA certificate inside the container
+    caCertFile: ""
+    # Client certificate and key for mutual TLS
+    certFile: ""
+    keyFile: ""
+    # Skip server certificate verification (NOT recommended for production)
+    insecure: false
+    # Verify server hostname against certificate CN/SAN.
+    # Off by default because managed Redis services and cluster mode
+    # expose node IPs that typically don't match certificate names.
+    checkHostname: false
 
 minio:
   # Reference an existing Kubernetes Secret containing S3 credentials
@@ -172,17 +205,36 @@ execution:
   # Image pull policy for execution pods (IfNotPresent, Always, Never)
   imagePullPolicy: "IfNotPresent"
 
+  # Image pull secrets for private registries (applies to execution pods)
+  # Example:
+  # imagePullSecrets:
+  #   - name: secret-for-registry
+  #   - name: another-secret
+  imagePullSecrets: []
+
   # Service account for execution pods (with pod/job create permissions)
   serviceAccount:
     create: true
     name: "kubecoderun-executor"
     annotations: {}
 
+  # Execution mode: "agent" (default) or "nsenter" (legacy)
+  # - agent: Executor agent runs inside main container. No nsenter, no capabilities,
+  #   no privilege escalation. Compatible with GKE Sandbox (gVisor). Requires the
+  #   sidecar-agent image (default build target).
+  # - nsenter: Sidecar uses nsenter to enter the main container's namespace. Requires
+  #   the sidecar-nsenter image, shareProcessNamespace, SYS_PTRACE/SYS_ADMIN/SYS_CHROOT
+  #   capabilities, and allowPrivilegeEscalation: true.
+  executionMode: "agent"
+
+  # Port for the executor HTTP server inside the main container
+  executorPort: 9090
+
   # Sidecar container configuration
-  # CRITICAL: User code runs in sidecar's cgroup via nsenter (Issue #32)
-  # These resource limits apply to user code execution, not the main container
+  # In nsenter mode: user code runs in sidecar's cgroup via nsenter
+  # In agent mode: sidecar only proxies requests, user code runs in main container's cgroup
   sidecar:
-    repository: ghcr.io/aron-muon/kubecoderun-sidecar
+    repository: ghcr.io/aron-muon/kubecoderun-sidecar-agent
     # tag defaults to Chart.AppVersion if not specified
     tag: ""
     port: 8080
@@ -284,6 +336,40 @@ execution:
   networkPolicy:
     enabled: true
     denyEgress: true
+
+  # GKE Sandbox (gVisor) Configuration
+  # Provides additional kernel isolation for untrusted workloads using gVisor
+  # See: https://docs.cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods
+  gkeSandbox:
+    # Enable GKE Sandbox for execution pods.
+    # WARNING: When enabled, pods require nodes with the gVisor runtime class.
+    # Pods will stay Pending on clusters without sandbox-enabled node pools.
+    enabled: false
+
+    # Runtime class name (default: gvisor for GKE)
+    runtimeClassName: "gvisor"
+
+    # Node selector for sandbox-enabled nodes
+    # GKE automatically adds sandbox.gke.io/runtime=gvisor to sandbox nodes
+    # Add additional selectors here if needed (e.g., for specific node pools)
+    nodeSelector: {}
+    # Example:
+    #   sandbox.gke.io/runtime: gvisor
+    #   cloud.google.com/gke-nodepool: sandbox-pool
+
+    # Custom tolerations for node pool taints
+    # GKE automatically adds toleration for sandbox.gke.io/runtime=gvisor
+    # Use this for additional custom taints (e.g., dedicated sandbox node pools)
+    customTolerations: []
+    # Example:
+    # - key: pool
+    #   operator: Equal
+    #   value: sandbox
+    #   effect: NoSchedule
+    # - key: sandbox.gke.io/runtime
+    #   operator: Equal
+    #   value: gvisor
+    #   effect: NoSchedule
 
 # Resource Limits Configuration
 resourceLimits:

--- a/src/config/kubernetes.py
+++ b/src/config/kubernetes.py
@@ -18,7 +18,7 @@ class KubernetesConfig:
     service_account: str = "kubecoderun-executor"
 
     # Sidecar configuration
-    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar-agent:latest"
     sidecar_port: int = 8080
 
     # Resource limits for execution pods
@@ -27,7 +27,9 @@ class KubernetesConfig:
     cpu_request: str = "100m"
     memory_request: str = "128Mi"
 
-    # Sidecar resource limits (CRITICAL: user code inherits these via nsenter)
+    # Sidecar resource limits
+    # In nsenter mode: user code runs in sidecar's cgroup via nsenter
+    # In agent mode: user code runs in main container's cgroup
     sidecar_cpu_limit: str = "500m"
     sidecar_memory_limit: str = "512Mi"
     sidecar_cpu_request: str = "100m"
@@ -38,6 +40,14 @@ class KubernetesConfig:
     run_as_group: int = 65532
     run_as_non_root: bool = True
     seccomp_profile_type: str = "RuntimeDefault"
+
+    # Execution mode: "agent" (default, no nsenter/capabilities needed) or "nsenter" (legacy)
+    # agent: Executor agent runs in main container, no privilege escalation or capabilities needed
+    # nsenter: Sidecar uses nsenter to enter main container namespace (requires capabilities)
+    execution_mode: str = "agent"
+
+    # Executor port (main container listens on this port for execution requests)
+    executor_port: int = 9090
 
     # Job settings (for languages with pool_size=0)
     job_ttl_seconds_after_finished: int = 60
@@ -52,6 +62,27 @@ class KubernetesConfig:
     # e.g., aronmuon/kubecoderun-python:latest
     image_registry: str = "aronmuon/kubecoderun"
     image_tag: str = "latest"
+    image_pull_policy: str = "Always"
+
+    # Image pull secrets for private registries
+    # Format: comma-separated list of secret names, e.g., "secret-for-registry,another-secret"
+    image_pull_secrets: str = ""
+
+    # GKE Sandbox (gVisor) configuration
+    # When enabled, pods run with additional kernel isolation via gVisor
+    gke_sandbox_enabled: bool = False
+
+    # Runtime class name for sandboxed pods (default: gvisor for GKE)
+    runtime_class_name: str = "gvisor"
+
+    # Node selector for sandbox nodes
+    # GKE automatically adds: sandbox.gke.io/runtime=gvisor
+    sandbox_node_selector: dict[str, str] | None = None
+
+    # Custom tolerations for execution pods
+    # GKE Sandbox automatically adds toleration for sandbox.gke.io/runtime=gvisor
+    # Use this for additional custom node pool taints (e.g., pool=sandbox)
+    custom_tolerations: list[dict[str, str]] | None = None
 
     def get_image_for_language(self, language: str) -> str:
         """Get the container image for a language.

--- a/src/config/redis.py
+++ b/src/config/redis.py
@@ -1,11 +1,25 @@
-"""Redis configuration."""
+"""Redis configuration.
 
-from pydantic import Field
+Supports three deployment modes:
+- **standalone** (default): Single Redis instance.
+- **cluster**: Redis Cluster with automatic slot routing.
+- **sentinel**: Redis Sentinel for high-availability failover.
+
+TLS/SSL is supported in all modes and is required for most managed Redis
+services such as GCP Memorystore, AWS ElastiCache, and Azure Cache for Redis.
+"""
+
+from typing import Literal
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class RedisConfig(BaseSettings):
-    """Redis connection settings."""
+    """Redis connection settings.
+
+    Supports standalone, cluster, and sentinel modes with optional TLS.
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="",
@@ -13,6 +27,14 @@ class RedisConfig(BaseSettings):
         populate_by_name=True,
     )
 
+    # -- Connection mode -------------------------------------------------------
+    mode: Literal["standalone", "cluster", "sentinel"] = Field(
+        default="standalone",
+        alias="redis_mode",
+        description="Redis deployment mode: standalone, cluster, or sentinel",
+    )
+
+    # -- Basic connection (standalone / single-entry for cluster & sentinel) ---
     host: str = Field(default="localhost", alias="redis_host")
     port: int = Field(default=6379, ge=1, le=65535, alias="redis_port")
     password: str | None = Field(default=None, alias="redis_password")
@@ -22,9 +44,193 @@ class RedisConfig(BaseSettings):
     socket_timeout: int = Field(default=5, ge=1, alias="redis_socket_timeout")
     socket_connect_timeout: int = Field(default=5, ge=1, alias="redis_socket_connect_timeout")
 
+    # -- Cluster mode ----------------------------------------------------------
+    cluster_nodes: str | None = Field(
+        default=None,
+        alias="redis_cluster_nodes",
+        description=(
+            "Comma-separated list of host:port pairs for Redis Cluster startup nodes. "
+            "Example: 'node1:6379,node2:6379,node3:6379'"
+        ),
+    )
+
+    # -- Sentinel mode ---------------------------------------------------------
+    sentinel_nodes: str | None = Field(
+        default=None,
+        alias="redis_sentinel_nodes",
+        description=(
+            "Comma-separated list of host:port pairs for Sentinel instances. "
+            "Example: 'sentinel1:26379,sentinel2:26379,sentinel3:26379'"
+        ),
+    )
+    sentinel_master: str = Field(
+        default="mymaster",
+        alias="redis_sentinel_master",
+        description="Name of the Sentinel-monitored master.",
+    )
+    sentinel_password: str | None = Field(
+        default=None,
+        alias="redis_sentinel_password",
+        description="Password for authenticating to Sentinel instances (if different from Redis password).",
+    )
+
+    # -- Key prefix ------------------------------------------------------------
+    key_prefix: str = Field(
+        default="",
+        alias="redis_key_prefix",
+        description=(
+            "Optional prefix prepended to every Redis key. "
+            "Useful for sharing a single Redis instance across multiple environments "
+            "or applications (e.g. 'prod:', 'staging:', 'kubecoderun:'). "
+            "Must end with a separator like ':' if you want one."
+        ),
+    )
+
+    # -- TLS / SSL -------------------------------------------------------------
+    tls_enabled: bool = Field(
+        default=False,
+        alias="redis_tls_enabled",
+        description="Enable TLS/SSL for Redis connections.",
+    )
+    tls_cert_file: str | None = Field(
+        default=None,
+        alias="redis_tls_cert_file",
+        description="Path to client TLS certificate file (mutual TLS).",
+    )
+    tls_key_file: str | None = Field(
+        default=None,
+        alias="redis_tls_key_file",
+        description="Path to client TLS private key file (mutual TLS).",
+    )
+    tls_ca_cert_file: str | None = Field(
+        default=None,
+        alias="redis_tls_ca_cert_file",
+        description="Path to CA certificate file for verifying the server.",
+    )
+    tls_insecure: bool = Field(
+        default=False,
+        alias="redis_tls_insecure",
+        description="Skip TLS certificate verification (NOT recommended for production).",
+    )
+    tls_check_hostname: bool = Field(
+        default=False,
+        alias="redis_tls_check_hostname",
+        description=(
+            "Enable TLS hostname verification. Disabled by default because "
+            "managed Redis services (GCP Memorystore, AWS ElastiCache) and "
+            "Redis Cluster mode expose node IPs that typically do not match "
+            "the certificate CN/SAN entries. The certificate chain is still "
+            "verified against the CA when tls_insecure is False."
+        ),
+    )
+
+    # -- Validators ------------------------------------------------------------
+
+    @field_validator("host", mode="before")
+    @classmethod
+    def _sanitize_host(cls, v: str) -> str:
+        """Strip an accidental URL scheme from the host value.
+
+        Users sometimes set ``REDIS_HOST=rediss://hostname`` instead of just
+        ``REDIS_HOST=hostname``.  This validator normalises the value so that
+        downstream code always receives a plain hostname or IP.
+        """
+        if isinstance(v, str):
+            for scheme in ("rediss://", "redis://"):
+                if v.lower().startswith(scheme):
+                    v = v[len(scheme) :]
+                    # Drop any trailing slash left over
+                    v = v.rstrip("/")
+                    break
+        return v
+
+    @field_validator("password", "sentinel_password", mode="before")
+    @classmethod
+    def _empty_string_to_none(cls, v: str | None) -> str | None:
+        """Convert empty strings to ``None``.
+
+        Kubernetes ConfigMaps and Helm values often set ``REDIS_PASSWORD: ""``
+        which pydantic-settings reads as ``""`` rather than ``None``.  Passing
+        an empty password to redis-py causes it to send ``AUTH ""`` which
+        fails when the server has no authentication configured.
+        """
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
+    @field_validator("cluster_nodes", "sentinel_nodes", mode="before")
+    @classmethod
+    def _empty_nodes_to_none(cls, v: str | None) -> str | None:
+        """Convert empty/whitespace-only node lists to ``None``.
+
+        Helm values default to ``clusterNodes: ""`` which renders in the
+        ConfigMap as an empty string.  This validator treats it the same
+        as "not set" so the code falls back to ``host:port``.
+        """
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
+    # -- Helpers ---------------------------------------------------------------
+
     def get_url(self) -> str:
-        """Get Redis connection URL."""
+        """Get Redis connection URL (standalone mode only).
+
+        For cluster/sentinel modes the URL is not used; startup nodes are
+        provided separately. This method honours an explicit ``url`` and
+        automatically switches between the ``redis://`` and ``rediss://``
+        scheme based on the ``tls_enabled`` flag.
+        """
         if self.url:
             return self.url
+        scheme = "rediss" if self.tls_enabled else "redis"
         password_part = f":{self.password}@" if self.password else ""
-        return f"redis://{password_part}{self.host}:{self.port}/{self.db}"
+        return f"{scheme}://{password_part}{self.host}:{self.port}/{self.db}"
+
+    def get_tls_kwargs(self) -> dict:
+        """Build keyword arguments for redis-py SSL/TLS configuration.
+
+        Returns an empty dict when TLS is disabled so callers can safely
+        unpack the result: ``redis.Redis(**config.get_tls_kwargs())``.
+        """
+        if not self.tls_enabled:
+            return {}
+
+        import ssl
+
+        kwargs: dict = {"ssl": True}
+
+        if self.tls_insecure:
+            kwargs["ssl_cert_reqs"] = ssl.CERT_NONE
+            kwargs["ssl_check_hostname"] = False
+        else:
+            kwargs["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+            # Hostname checking is off by default because managed Redis
+            # services (GCP Memorystore, AWS ElastiCache) and Redis
+            # Cluster node discovery return IPs that do not match the
+            # certificate CN/SAN.  The certificate chain is still fully
+            # validated against the CA.
+            kwargs["ssl_check_hostname"] = self.tls_check_hostname
+
+        if self.tls_ca_cert_file:
+            kwargs["ssl_ca_certs"] = self.tls_ca_cert_file
+        if self.tls_cert_file:
+            kwargs["ssl_certfile"] = self.tls_cert_file
+        if self.tls_key_file:
+            kwargs["ssl_keyfile"] = self.tls_key_file
+
+        return kwargs
+
+    def parse_nodes(self, raw: str) -> list[tuple[str, int]]:
+        """Parse a comma-separated ``host:port`` string into a list of tuples."""
+        nodes: list[tuple[str, int]] = []
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            if ":" in entry:
+                h, p = entry.rsplit(":", 1)
+                nodes.append((h.strip(), int(p.strip())))
+            else:
+                nodes.append((entry, self.port))
+        return nodes

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -2,14 +2,32 @@
 
 This module provides centralized connection pools for external services,
 allowing efficient resource sharing across the application.
+
+Supported Redis deployment modes:
+- **standalone** (default): Single Redis server with ``ConnectionPool``.
+- **cluster**: Redis Cluster via ``RedisCluster``.
+- **sentinel**: Redis Sentinel via ``Sentinel`` for HA failover.
+
+All modes support optional TLS/SSL for managed services such as
+GCP Memorystore, AWS ElastiCache, and Azure Cache for Redis.
 """
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import redis.asyncio as redis
 import structlog
+from redis.asyncio.cluster import RedisCluster
+from redis.asyncio.sentinel import Sentinel
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError, TimeoutError
+from redis.retry import Retry
 
 from ..config import settings
+
+if TYPE_CHECKING:
+    from ..config.redis import RedisConfig
 
 logger = structlog.get_logger(__name__)
 
@@ -18,51 +36,159 @@ class RedisPool:
     """Centralized async Redis connection pool.
 
     Provides a shared connection pool for all services that need Redis,
-    avoiding the overhead of multiple separate pools.
+    avoiding the overhead of multiple separate pools.  Supports standalone,
+    cluster, and sentinel modes with optional TLS.
 
     Usage:
         client = redis_pool.get_client()
         await client.set("key", "value")
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._pool: redis.ConnectionPool | None = None
-        self._client: redis.Redis | None = None
-        self._initialized = False
+        self._client: redis.Redis | RedisCluster | None = None
+        self._sentinel: Sentinel | None = None
+        self._initialized: bool = False
+        self._mode: str = "standalone"
+        self._key_prefix: str = ""
 
     def _initialize(self) -> None:
-        """Initialize the connection pool lazily."""
+        """Initialize the connection pool lazily based on the configured mode."""
         if self._initialized:
             return
 
         try:
-            redis_url = settings.get_redis_url()
-            self._pool = redis.ConnectionPool.from_url(
-                redis_url,
-                max_connections=20,  # Shared across all services
-                decode_responses=True,
-                socket_timeout=5.0,
-                socket_connect_timeout=5.0,
-                retry_on_timeout=True,
-            )
-            self._client = redis.Redis(connection_pool=self._pool)
-            self._initialized = True
-            logger.info(
-                "Redis connection pool initialized",
-                max_connections=20,
-                url=redis_url.split("@")[-1],  # Don't log password
-            )
-        except Exception as e:
-            logger.error("Failed to initialize Redis pool", error=str(e))
-            # Create a fallback client
-            self._client = redis.from_url("redis://localhost:6379/0", decode_responses=True)
-            self._initialized = True
+            redis_cfg = settings.redis
+            self._mode = redis_cfg.mode
+            self._key_prefix = redis_cfg.key_prefix
+            tls_kwargs = redis_cfg.get_tls_kwargs()
+            max_conns = redis_cfg.max_connections
+            socket_timeout = float(redis_cfg.socket_timeout)
+            socket_connect_timeout = float(redis_cfg.socket_connect_timeout)
 
-    def get_client(self) -> redis.Redis:
+            if self._mode == "cluster":
+                self._init_cluster(redis_cfg, tls_kwargs, max_conns, socket_timeout, socket_connect_timeout)
+            elif self._mode == "sentinel":
+                self._init_sentinel(redis_cfg, tls_kwargs, max_conns, socket_timeout, socket_connect_timeout)
+            else:
+                self._init_standalone(redis_cfg, tls_kwargs, max_conns, socket_timeout, socket_connect_timeout)
+
+            self._initialized = True
+        except Exception as e:
+            logger.error(
+                "Failed to initialize Redis pool",
+                error=str(e),
+                mode=self._mode,
+            )
+            raise
+
+    # -- Mode-specific initialisers -------------------------------------------
+
+    def _init_standalone(
+        self,
+        cfg: RedisConfig,
+        tls_kwargs: dict,
+        max_conns: int,
+        socket_timeout: float,
+        socket_connect_timeout: float,
+    ) -> None:
+        redis_url = cfg.get_url()
+        self._pool = redis.ConnectionPool.from_url(
+            redis_url,
+            max_connections=max_conns,
+            decode_responses=True,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            retry_on_timeout=True,
+            **tls_kwargs,
+        )
+        self._client = redis.Redis(connection_pool=self._pool)
+        logger.info(
+            "Redis standalone connection pool initialized",
+            max_connections=max_conns,
+            tls=cfg.tls_enabled,
+            url=redis_url.split("@")[-1],
+        )
+
+    def _init_cluster(
+        self,
+        cfg: RedisConfig,
+        tls_kwargs: dict,
+        max_conns: int,
+        socket_timeout: float,
+        socket_connect_timeout: float,
+    ) -> None:
+        if cfg.cluster_nodes:
+            startup_nodes = [redis.cluster.ClusterNode(host=h, port=p) for h, p in cfg.parse_nodes(cfg.cluster_nodes)]
+        else:
+            startup_nodes = [redis.cluster.ClusterNode(host=cfg.host, port=cfg.port)]
+
+        self._client = RedisCluster(
+            startup_nodes=startup_nodes,
+            password=cfg.password,
+            decode_responses=True,
+            max_connections=max_conns,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            retry=Retry(ExponentialBackoff(), retries=3),
+            retry_on_error=[ConnectionError, TimeoutError],
+            **tls_kwargs,
+        )
+        logger.info(
+            "Redis cluster connection initialized",
+            startup_nodes=[
+                f"{h}:{p}"
+                for h, p in (cfg.parse_nodes(cfg.cluster_nodes) if cfg.cluster_nodes else [(cfg.host, cfg.port)])
+            ],
+            tls=cfg.tls_enabled,
+        )
+
+    def _init_sentinel(
+        self,
+        cfg: RedisConfig,
+        tls_kwargs: dict,
+        max_conns: int,
+        socket_timeout: float,
+        socket_connect_timeout: float,
+    ) -> None:
+        if cfg.sentinel_nodes:
+            sentinel_hosts = cfg.parse_nodes(cfg.sentinel_nodes)
+        else:
+            sentinel_hosts = [(cfg.host, 26379)]
+
+        self._sentinel = Sentinel(
+            sentinels=sentinel_hosts,
+            password=cfg.sentinel_password,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            **tls_kwargs,
+        )
+        self._client = self._sentinel.master_for(
+            service_name=cfg.sentinel_master,
+            password=cfg.password,
+            decode_responses=True,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            max_connections=max_conns,
+            retry_on_timeout=True,
+            **tls_kwargs,
+        )
+        logger.info(
+            "Redis sentinel connection initialized",
+            sentinel_nodes=[f"{h}:{p}" for h, p in sentinel_hosts],
+            master=cfg.sentinel_master,
+            tls=cfg.tls_enabled,
+        )
+
+    # -- Public API -----------------------------------------------------------
+
+    def get_client(self) -> redis.Redis | RedisCluster:
         """Get an async Redis client from the shared pool.
 
         Returns:
-            Async Redis client instance connected to the shared pool
+            Async Redis client instance connected to the shared pool.
+            For cluster mode this is a ``RedisCluster`` instance which
+            exposes the same command interface.
         """
         if not self._initialized:
             self._initialize()
@@ -70,24 +196,49 @@ class RedisPool:
         return self._client
 
     @property
+    def key_prefix(self) -> str:
+        """Return the configured Redis key prefix (may be empty)."""
+        if not self._initialized:
+            self._initialize()
+        return self._key_prefix
+
+    def make_key(self, key: str) -> str:
+        """Prepend the configured key prefix to *key*.
+
+        Returns *key* unchanged when no prefix is configured.
+        """
+        prefix = self.key_prefix
+        if prefix:
+            return f"{prefix}{key}"
+        return key
+
+    @property
     def pool_stats(self) -> dict:
         """Get connection pool statistics."""
-        if not self._pool:
-            return {"initialized": False}
+        if not self._pool and self._mode == "standalone":
+            return {"initialized": self._initialized, "mode": self._mode}
 
-        return {
-            "initialized": True,
-            "max_connections": self._pool.max_connections,
-        }
+        stats: dict = {"initialized": self._initialized, "mode": self._mode}
+
+        if self._key_prefix:
+            stats["key_prefix"] = self._key_prefix
+
+        if self._pool:
+            stats["max_connections"] = self._pool.max_connections
+
+        return stats
 
     async def close(self) -> None:
         """Close the connection pool and release all connections."""
         if self._client:
             await self._client.close()
-            logger.info("Redis connection pool closed")
+            logger.info("Redis connection pool closed", mode=self._mode)
         self._pool = None
         self._client = None
+        self._sentinel = None
         self._initialized = False
+        self._mode = "standalone"
+        self._key_prefix = ""
 
 
 # Global Redis pool instance

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -206,7 +206,7 @@ class RedisPool:
         """Prepend the configured key prefix to *key*.
 
         Returns *key* unchanged when no prefix is configured.
-        
+
         This is a pure string operation that does not trigger Redis pool
         initialization. The prefix is loaded directly from settings if the
         pool has not been initialized yet.
@@ -220,7 +220,7 @@ class RedisPool:
                 prefix = settings.redis.key_prefix
             except Exception:
                 prefix = ""
-        
+
         if prefix:
             return f"{prefix}{key}"
         return key

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 import redis.asyncio as redis
 import structlog
-from redis.asyncio.cluster import RedisCluster
+from redis.asyncio.cluster import ClusterNode, RedisCluster
 from redis.asyncio.sentinel import Sentinel
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError, TimeoutError
@@ -119,9 +119,9 @@ class RedisPool:
         socket_connect_timeout: float,
     ) -> None:
         if cfg.cluster_nodes:
-            startup_nodes = [redis.cluster.ClusterNode(host=h, port=p) for h, p in cfg.parse_nodes(cfg.cluster_nodes)]
+            startup_nodes = [ClusterNode(host=h, port=p) for h, p in cfg.parse_nodes(cfg.cluster_nodes)]
         else:
-            startup_nodes = [redis.cluster.ClusterNode(host=cfg.host, port=cfg.port)]
+            startup_nodes = [ClusterNode(host=cfg.host, port=cfg.port)]
 
         self._client = RedisCluster(
             startup_nodes=startup_nodes,
@@ -206,8 +206,21 @@ class RedisPool:
         """Prepend the configured key prefix to *key*.
 
         Returns *key* unchanged when no prefix is configured.
+        
+        This is a pure string operation that does not trigger Redis pool
+        initialization. The prefix is loaded directly from settings if the
+        pool has not been initialized yet.
         """
-        prefix = self.key_prefix
+        # Avoid triggering Redis pool initialization for simple key construction
+        if self._initialized:
+            prefix = self._key_prefix
+        else:
+            # Load prefix directly from settings without initializing the pool
+            try:
+                prefix = settings.redis.key_prefix
+            except Exception:
+                prefix = ""
+        
         if prefix:
             return f"{prefix}{key}"
         return key

--- a/src/services/api_key_manager.py
+++ b/src/services/api_key_manager.py
@@ -56,7 +56,7 @@ class ApiKeyManagerService:
             prefix = settings.redis.key_prefix
         except Exception:
             prefix = ""
-        
+
         self.RECORD_PREFIX = f"{prefix}{self._RECORD_PREFIX}"
         self.VALID_CACHE_PREFIX = f"{prefix}{self._VALID_CACHE_PREFIX}"
         self.USAGE_PREFIX = f"{prefix}{self._USAGE_PREFIX}"

--- a/src/services/api_key_manager.py
+++ b/src/services/api_key_manager.py
@@ -49,13 +49,19 @@ class ApiKeyManagerService:
         """
         self._redis = redis_client
 
-        # Compute prefixed keys once so every method uses the prefix
-        mk = redis_pool.make_key
-        self.RECORD_PREFIX = mk(self._RECORD_PREFIX)
-        self.VALID_CACHE_PREFIX = mk(self._VALID_CACHE_PREFIX)
-        self.USAGE_PREFIX = mk(self._USAGE_PREFIX)
-        self.INDEX_KEY = mk(self._INDEX_KEY)
-        self.ENV_KEYS_INDEX = mk(self._ENV_KEYS_INDEX)
+        # Compute prefixed keys once so every method uses the prefix.
+        # Load prefix directly from settings to avoid triggering Redis pool
+        # initialization during service construction (important for tests/mocks).
+        try:
+            prefix = settings.redis.key_prefix
+        except Exception:
+            prefix = ""
+        
+        self.RECORD_PREFIX = f"{prefix}{self._RECORD_PREFIX}"
+        self.VALID_CACHE_PREFIX = f"{prefix}{self._VALID_CACHE_PREFIX}"
+        self.USAGE_PREFIX = f"{prefix}{self._USAGE_PREFIX}"
+        self.INDEX_KEY = f"{prefix}{self._INDEX_KEY}"
+        self.ENV_KEYS_INDEX = f"{prefix}{self._ENV_KEYS_INDEX}"
 
     @property
     def redis(self) -> redis.Redis:

--- a/src/services/detailed_metrics.py
+++ b/src/services/detailed_metrics.py
@@ -31,12 +31,12 @@ logger = structlog.get_logger(__name__)
 class DetailedMetricsService:
     """Service for collecting and querying detailed execution metrics."""
 
-    # Redis key prefixes
-    BUFFER_KEY = "metrics:detailed:buffer"
-    HOURLY_PREFIX = "metrics:detailed:hourly:"
-    DAILY_PREFIX = "metrics:detailed:daily:"
-    POOL_STATS_KEY = "metrics:pool:stats"
-    API_KEY_HOURLY_PREFIX = "metrics:api_key:"
+    # Base Redis key prefixes (before application-level prefix)
+    _BUFFER_KEY = "metrics:detailed:buffer"
+    _HOURLY_PREFIX = "metrics:detailed:hourly:"
+    _DAILY_PREFIX = "metrics:detailed:daily:"
+    _POOL_STATS_KEY = "metrics:pool:stats"
+    _API_KEY_HOURLY_PREFIX = "metrics:api_key:"
 
     # Buffer and retention settings
     MAX_BUFFER_SIZE = 10000
@@ -51,6 +51,16 @@ class DetailedMetricsService:
         """
         self._redis = redis_client
         self._in_memory_buffer: list[DetailedExecutionMetrics] = []
+
+        # Compute prefixed keys once
+        from ..core.pool import redis_pool
+
+        mk = redis_pool.make_key
+        self.BUFFER_KEY = mk(self._BUFFER_KEY)
+        self.HOURLY_PREFIX = mk(self._HOURLY_PREFIX)
+        self.DAILY_PREFIX = mk(self._DAILY_PREFIX)
+        self.POOL_STATS_KEY = mk(self._POOL_STATS_KEY)
+        self.API_KEY_HOURLY_PREFIX = mk(self._API_KEY_HOURLY_PREFIX)
 
     def register_event_handlers(self) -> None:
         """Register event handlers for pool metrics."""

--- a/src/services/detailed_metrics.py
+++ b/src/services/detailed_metrics.py
@@ -52,15 +52,19 @@ class DetailedMetricsService:
         self._redis = redis_client
         self._in_memory_buffer: list[DetailedExecutionMetrics] = []
 
-        # Compute prefixed keys once
-        from ..core.pool import redis_pool
-
-        mk = redis_pool.make_key
-        self.BUFFER_KEY = mk(self._BUFFER_KEY)
-        self.HOURLY_PREFIX = mk(self._HOURLY_PREFIX)
-        self.DAILY_PREFIX = mk(self._DAILY_PREFIX)
-        self.POOL_STATS_KEY = mk(self._POOL_STATS_KEY)
-        self.API_KEY_HOURLY_PREFIX = mk(self._API_KEY_HOURLY_PREFIX)
+        # Compute prefixed keys once.
+        # Load prefix directly from settings to avoid triggering Redis pool
+        # initialization during service construction (important for tests/mocks).
+        try:
+            prefix = settings.redis.key_prefix
+        except Exception:
+            prefix = ""
+        
+        self.BUFFER_KEY = f"{prefix}{self._BUFFER_KEY}"
+        self.HOURLY_PREFIX = f"{prefix}{self._HOURLY_PREFIX}"
+        self.DAILY_PREFIX = f"{prefix}{self._DAILY_PREFIX}"
+        self.POOL_STATS_KEY = f"{prefix}{self._POOL_STATS_KEY}"
+        self.API_KEY_HOURLY_PREFIX = f"{prefix}{self._API_KEY_HOURLY_PREFIX}"
 
     def register_event_handlers(self) -> None:
         """Register event handlers for pool metrics."""

--- a/src/services/detailed_metrics.py
+++ b/src/services/detailed_metrics.py
@@ -59,7 +59,7 @@ class DetailedMetricsService:
             prefix = settings.redis.key_prefix
         except Exception:
             prefix = ""
-        
+
         self.BUFFER_KEY = f"{prefix}{self._BUFFER_KEY}"
         self.HOURLY_PREFIX = f"{prefix}{self._HOURLY_PREFIX}"
         self.DAILY_PREFIX = f"{prefix}{self._DAILY_PREFIX}"

--- a/src/services/health.py
+++ b/src/services/health.py
@@ -142,16 +142,16 @@ class HealthCheckService:
 
         try:
             # Use shared connection pool
-            if not self._redis_client:
-                from ..core.pool import redis_pool
+            from ..core.pool import redis_pool
 
+            if not self._redis_client:
                 self._redis_client = redis_pool.get_client()
 
             # Test basic connectivity
             await self._redis_client.ping()
 
             # Test read/write operations
-            test_key = "health_check:test"
+            test_key = redis_pool.make_key("health_check:test")
             test_value = f"test_{int(time.time())}"
 
             await self._redis_client.set(test_key, test_value, ex=60)

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -240,7 +240,7 @@ def create_pod_manifest(
 
     Returns:
         V1Pod manifest ready for creation.
-    
+
     Raises:
         ValueError: If execution_mode is not 'agent' or 'nsenter'.
     """
@@ -250,7 +250,7 @@ def create_pod_manifest(
             f"Invalid execution_mode '{execution_mode}'. "
             "Must be 'agent' (recommended, no capabilities) or 'nsenter' (legacy, requires capabilities)."
         )
-    
+
     use_agent = execution_mode == "agent"
 
     # Warn if GKE Sandbox is enabled with nsenter mode (incompatible with gVisor)

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -200,6 +200,7 @@ def create_pod_manifest(
     sandbox_node_selector: dict[str, str] | None = None,
     custom_tolerations: list[dict[str, str]] | None = None,
     image_pull_secrets: list[str] | None = None,
+    agent_init_image: str | None = None,
 ) -> client.V1Pod:
     """Create a Pod manifest for code execution.
 
@@ -243,6 +244,13 @@ def create_pod_manifest(
 
     Raises:
         ValueError: If execution_mode is not 'agent' or 'nsenter'.
+
+    Note:
+        In agent mode the init container copies ``/opt/executor-agent`` from
+        ``agent_init_image`` (defaults to ``sidecar_image`` when *None*).  If
+        the sidecar image used at runtime is the nsenter variant (which does
+        not ship the binary), pass the agent-sidecar image explicitly via
+        ``agent_init_image`` to avoid an init-container startup failure.
     """
     # Validate execution_mode to prevent silent security downgrades from typos
     if execution_mode not in ("agent", "nsenter"):
@@ -383,13 +391,17 @@ def create_pod_manifest(
     )
 
     # Init containers (agent mode only)
-    # Copy the executor agent binary from the sidecar image to the shared volume
+    # Copy the executor agent binary from the sidecar image to the shared volume.
+    # Use agent_init_image if provided; fall back to sidecar_image.
+    # Callers that use the nsenter sidecar variant at runtime should pass the
+    # agent sidecar image explicitly so the init container finds /opt/executor-agent.
+    _agent_source_image = agent_init_image if agent_init_image is not None else sidecar_image
     init_containers = None
     if use_agent:
         init_containers = [
             client.V1Container(
                 name="agent-init",
-                image=sidecar_image,
+                image=_agent_source_image,
                 image_pull_policy=image_pull_policy,
                 command=[
                     "python",

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -240,7 +240,17 @@ def create_pod_manifest(
 
     Returns:
         V1Pod manifest ready for creation.
+    
+    Raises:
+        ValueError: If execution_mode is not 'agent' or 'nsenter'.
     """
+    # Validate execution_mode to prevent silent security downgrades from typos
+    if execution_mode not in ("agent", "nsenter"):
+        raise ValueError(
+            f"Invalid execution_mode '{execution_mode}'. "
+            "Must be 'agent' (recommended, no capabilities) or 'nsenter' (legacy, requires capabilities)."
+        )
+    
     use_agent = execution_mode == "agent"
 
     # Warn if GKE Sandbox is enabled with nsenter mode (incompatible with gVisor)
@@ -406,22 +416,26 @@ def create_pod_manifest(
     runtime_class = runtime_class_name if gke_sandbox_enabled else None
 
     # Build node selector
+    # Derive sandbox runtime value from runtime_class_name to ensure consistency
+    # between runtimeClassName, node selector, tolerations, and annotations
     node_selector = {}
     if gke_sandbox_enabled:
         # GKE automatically adds this label to sandbox-enabled nodes
-        node_selector["sandbox.gke.io/runtime"] = "gvisor"
+        # Use runtime_class_name to ensure consistency across the pod spec
+        node_selector["sandbox.gke.io/runtime"] = runtime_class_name
     if sandbox_node_selector:
         node_selector.update(sandbox_node_selector)
 
     # Build tolerations list
     tolerations = []
     if gke_sandbox_enabled:
-        # GKE Sandbox standard taint
+        # GKE Sandbox standard taint - derive value from runtime_class_name
+        # to maintain consistency across pod scheduling attributes
         tolerations.append(
             client.V1Toleration(
                 key="sandbox.gke.io/runtime",
                 operator="Equal",
-                value="gvisor",
+                value=runtime_class_name,
                 effect="NoSchedule",
             )
         )
@@ -469,8 +483,9 @@ def create_pod_manifest(
     # Add GKE Sandbox annotation if enabled
     pod_annotations = dict(annotations) if annotations else {}
     if gke_sandbox_enabled:
-        # GKE Sandbox annotation for gVisor runtime
-        pod_annotations["sandbox.gke.io/runtime"] = "gvisor"
+        # GKE Sandbox annotation - use runtime_class_name for consistency
+        # with runtimeClassName, node selector, and tolerations
+        pod_annotations["sandbox.gke.io/runtime"] = runtime_class_name
 
     metadata = client.V1ObjectMeta(
         name=name,

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -5,8 +5,6 @@ for each execution. This has higher latency but simpler management.
 """
 
 import asyncio
-from datetime import datetime
-from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import httpx
@@ -41,7 +39,7 @@ class JobExecutor:
         namespace: str | None = None,
         ttl_seconds_after_finished: int = 60,
         active_deadline_seconds: int = 300,
-        sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest",
+        sidecar_image: str = "aronmuon/kubecoderun-sidecar-agent:latest",
     ):
         """Initialize the Job executor.
 
@@ -123,8 +121,16 @@ class JobExecutor:
             sidecar_memory_limit=spec.sidecar_memory_limit,
             sidecar_cpu_request=spec.sidecar_cpu_request,
             sidecar_memory_request=spec.sidecar_memory_request,
+            execution_mode=spec.execution_mode,
+            executor_port=spec.executor_port,
             seccomp_profile_type=spec.seccomp_profile_type,
             network_isolated=spec.network_isolated,
+            gke_sandbox_enabled=spec.gke_sandbox_enabled,
+            runtime_class_name=spec.runtime_class_name,
+            sandbox_node_selector=spec.sandbox_node_selector,
+            custom_tolerations=spec.custom_tolerations,
+            image_pull_policy=spec.image_pull_policy,
+            image_pull_secrets=spec.image_pull_secrets,
             ttl_seconds_after_finished=self.ttl_seconds_after_finished,
             active_deadline_seconds=self.active_deadline_seconds,
         )

--- a/src/services/kubernetes/models.py
+++ b/src/services/kubernetes/models.py
@@ -106,7 +106,9 @@ class PodSpec:
     cpu_request: str = "100m"
     memory_request: str = "128Mi"
 
-    # Sidecar resource limits (CRITICAL: user code runs in sidecar's cgroup via nsenter)
+    # Sidecar resource limits
+    # In nsenter mode: user code runs in sidecar's cgroup via nsenter
+    # In agent mode: user code runs in main container's cgroup
     sidecar_cpu_limit: str = "500m"
     sidecar_memory_limit: str = "512Mi"
     sidecar_cpu_request: str = "100m"
@@ -116,14 +118,26 @@ class PodSpec:
     run_as_user: int = 65532
     run_as_group: int = 65532
     run_as_non_root: bool = True
+    execution_mode: str = "agent"  # "agent" or "nsenter"
+    executor_port: int = 9090
     seccomp_profile_type: str = "RuntimeDefault"
 
     # Sidecar configuration
-    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar-agent:latest"
     sidecar_port: int = 8080
+
+    # Image pull policy and secrets
+    image_pull_policy: str = "Always"
+    image_pull_secrets: list[str] | None = None
 
     # Network isolation mode - disables network-dependent features (e.g., Go module proxy)
     network_isolated: bool = False
+
+    # GKE Sandbox (gVisor) configuration
+    gke_sandbox_enabled: bool = False
+    runtime_class_name: str = "gvisor"
+    sandbox_node_selector: dict[str, str] | None = None
+    custom_tolerations: list[dict[str, str]] | None = None
 
 
 @dataclass
@@ -133,13 +147,15 @@ class PoolConfig:
     language: str
     image: str
     pool_size: int = 0  # 0 = use Jobs instead of pool
-    sidecar_image: str = "aronmuon/kubecoderun-sidecar:latest"
+    sidecar_image: str = "aronmuon/kubecoderun-sidecar-agent:latest"
 
     # Resource limits (can override defaults)
     cpu_limit: str | None = None
     memory_limit: str | None = None
 
-    # Sidecar resource limits (CRITICAL: user code runs in sidecar's cgroup via nsenter)
+    # Sidecar resource limits
+    # In nsenter mode: user code runs in sidecar's cgroup via nsenter
+    # In agent mode: user code runs in main container's cgroup
     sidecar_cpu_limit: str = "500m"
     sidecar_memory_limit: str = "512Mi"
     sidecar_cpu_request: str = "100m"
@@ -148,11 +164,22 @@ class PoolConfig:
     # Image pull policy (Always, IfNotPresent, Never)
     image_pull_policy: str = "Always"
 
-    # Seccomp profile type (RuntimeDefault, Unconfined, Localhost)
+    # Image pull secrets (list of secret names)
+    image_pull_secrets: list[str] | None = None
+
+    # Execution mode and security settings
+    execution_mode: str = "agent"  # "agent" or "nsenter"
+    executor_port: int = 9090
     seccomp_profile_type: str = "RuntimeDefault"
 
     # Network isolation mode - disables network-dependent features (e.g., Go module proxy)
     network_isolated: bool = False
+
+    # GKE Sandbox (gVisor) configuration
+    gke_sandbox_enabled: bool = False
+    runtime_class_name: str = "gvisor"
+    sandbox_node_selector: dict[str, str] | None = None
+    custom_tolerations: list[dict[str, str]] | None = None
 
     @property
     def uses_pool(self) -> bool:

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -188,8 +188,15 @@ class PodPool:
             sidecar_memory_limit=self.config.sidecar_memory_limit,
             sidecar_cpu_request=self.config.sidecar_cpu_request,
             sidecar_memory_request=self.config.sidecar_memory_request,
+            execution_mode=self.config.execution_mode,
+            executor_port=self.config.executor_port,
             seccomp_profile_type=self.config.seccomp_profile_type,
             network_isolated=self.config.network_isolated,
+            gke_sandbox_enabled=self.config.gke_sandbox_enabled,
+            runtime_class_name=self.config.runtime_class_name,
+            sandbox_node_selector=self.config.sandbox_node_selector,
+            custom_tolerations=self.config.custom_tolerations,
+            image_pull_secrets=self.config.image_pull_secrets,
         )
 
         try:

--- a/src/services/metrics.py
+++ b/src/services/metrics.py
@@ -391,8 +391,10 @@ class MetricsCollector:
             }
 
             # Store in Redis with TTL
+            from ..core.pool import redis_pool
+
             await self._redis_client.setex(
-                "metrics:current",
+                redis_pool.make_key("metrics:current"),
                 86400,
                 str(metrics_data),  # 24 hours TTL
             )
@@ -400,7 +402,7 @@ class MetricsCollector:
             # Store historical data (keep last 24 hours)
             hour_key = datetime.now(UTC).strftime("%Y-%m-%d-%H")
             await self._redis_client.setex(
-                f"metrics:hourly:{hour_key}",
+                redis_pool.make_key(f"metrics:hourly:{hour_key}"),
                 86400 * 7,  # 7 days TTL for hourly data
                 str(metrics_data),
             )
@@ -417,7 +419,9 @@ class MetricsCollector:
 
         try:
             # Load current metrics
-            current_data = await self._redis_client.get("metrics:current")
+            from ..core.pool import redis_pool
+
+            current_data = await self._redis_client.get(redis_pool.make_key("metrics:current"))
             if current_data:
                 # In a full implementation, we would parse and restore the metrics
                 # For now, just log that we found existing data

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -110,7 +110,7 @@ def configure_third_party_loggers() -> None:
 def add_service_context(logger, method_name, event_dict):
     """Add service context information to log entries."""
     event_dict["service"] = "kubecoderun-api"
-    event_dict["version"] = __version__
+    event_dict["version"] = settings.service_version or __version__
     return event_dict
 
 

--- a/tests/unit/test_cluster_pipeline_compat.py
+++ b/tests/unit/test_cluster_pipeline_compat.py
@@ -1,0 +1,244 @@
+"""Unit tests verifying that all Redis pipelines use transaction=False.
+
+Redis Cluster does not support MULTI/EXEC transactions across keys in
+different hash slots.  Every pipeline that touches keys with different
+prefixes (e.g. session data + session index) MUST use transaction=False
+so redis-py's ClusterPipeline can split commands by node.
+
+These tests act as a safety net: if someone accidentally changes a
+pipeline back to transaction=True, the test will catch it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.session import SessionCreate
+from src.services.api_key_manager import ApiKeyManagerService
+from src.services.session import SessionService
+from src.services.state import StateService
+
+# ── Session Service ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_redis_session():
+    """Mock Redis client for session tests."""
+    redis_mock = AsyncMock()
+
+    pipeline_mock = AsyncMock()
+    pipeline_mock.hset = MagicMock()
+    pipeline_mock.expire = MagicMock()
+    pipeline_mock.sadd = MagicMock()
+    pipeline_mock.delete = MagicMock()
+    pipeline_mock.srem = MagicMock()
+    pipeline_mock.execute = AsyncMock(return_value=[True, True, True])
+    pipeline_mock.reset = AsyncMock()
+
+    redis_mock.pipeline = MagicMock(return_value=pipeline_mock)
+    redis_mock.hgetall = AsyncMock(return_value={})
+    return redis_mock
+
+
+@pytest.fixture
+def session_service(mock_redis_session):
+    return SessionService(redis_client=mock_redis_session)
+
+
+@pytest.mark.asyncio
+async def test_session_create_uses_non_transactional_pipeline(session_service, mock_redis_session):
+    """create_session() must use transaction=False for cluster compat."""
+    request = SessionCreate(metadata={"test": "value"})
+    await session_service.create_session(request)
+
+    mock_redis_session.pipeline.assert_called_once_with(transaction=False)
+
+
+@pytest.mark.asyncio
+async def test_session_delete_uses_non_transactional_pipeline(session_service, mock_redis_session):
+    """delete_session() must use transaction=False for cluster compat."""
+    session_id = "session-to-delete"
+    # Provide minimal session data so delete_session finds the session
+    mock_redis_session.hgetall.return_value = {
+        "session_id": session_id,
+        "status": "active",
+        "created_at": "2025-01-01T00:00:00",
+        "last_activity": "2025-01-01T00:00:00",
+        "expires_at": "2026-01-01T00:00:00",
+        "files": "{}",
+        "metadata": "{}",
+        "working_directory": "/workspace",
+    }
+
+    pipeline_mock = mock_redis_session.pipeline.return_value
+    pipeline_mock.execute = AsyncMock(return_value=[1, 1])
+
+    await session_service.delete_session(session_id)
+
+    mock_redis_session.pipeline.assert_called_with(transaction=False)
+
+
+# ── API Key Manager ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_redis_apikey():
+    """Mock Redis client for API key manager tests."""
+    redis_mock = AsyncMock()
+    redis_mock.hgetall = AsyncMock(return_value={})
+    redis_mock.hset = AsyncMock(return_value=1)
+    redis_mock.exists = AsyncMock(return_value=True)
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.sadd = AsyncMock(return_value=1)
+    redis_mock.srem = AsyncMock(return_value=1)
+    redis_mock.smembers = AsyncMock(return_value=set())
+    redis_mock.get = AsyncMock(return_value=None)
+    redis_mock.setex = AsyncMock(return_value=True)
+    redis_mock.incr = AsyncMock(return_value=1)
+    redis_mock.expire = AsyncMock(return_value=True)
+    redis_mock.hincrby = AsyncMock(return_value=1)
+
+    pipeline_mock = AsyncMock()
+    pipeline_mock.hset = MagicMock()
+    pipeline_mock.sadd = MagicMock()
+    pipeline_mock.delete = MagicMock()
+    pipeline_mock.srem = MagicMock()
+    pipeline_mock.incr = MagicMock()
+    pipeline_mock.expire = MagicMock()
+    pipeline_mock.hincrby = MagicMock()
+    pipeline_mock.execute = AsyncMock(return_value=[True, True, True])
+    redis_mock.pipeline = MagicMock(return_value=pipeline_mock)
+
+    return redis_mock
+
+
+@pytest.fixture
+def api_key_manager(mock_redis_apikey):
+    return ApiKeyManagerService(redis_client=mock_redis_apikey)
+
+
+@pytest.mark.asyncio
+async def test_create_key_uses_non_transactional_pipeline(api_key_manager, mock_redis_apikey):
+    """create_key() must use transaction=False for cluster compat."""
+    result = await api_key_manager.create_key(
+        name="test-key",
+    )
+
+    # create_key calls pipeline at least once
+    mock_redis_apikey.pipeline.assert_called()
+    for call in mock_redis_apikey.pipeline.call_args_list:
+        assert call == ((), {"transaction": False}), f"Expected pipeline(transaction=False), got {call}"
+
+
+@pytest.mark.asyncio
+async def test_ensure_single_env_key_uses_non_transactional_pipeline(api_key_manager, mock_redis_apikey):
+    """_ensure_single_env_key_record() must use transaction=False."""
+    # Call the internal method directly
+    await api_key_manager._ensure_single_env_key_record("test-hash", "test-env")
+
+    mock_redis_apikey.pipeline.assert_called()
+    for call in mock_redis_apikey.pipeline.call_args_list:
+        assert call == ((), {"transaction": False}), f"Expected pipeline(transaction=False), got {call}"
+
+
+@pytest.mark.asyncio
+async def test_revoke_key_uses_non_transactional_pipeline(api_key_manager, mock_redis_apikey):
+    """revoke_key() must use transaction=False for cluster compat."""
+    # Setup: make the key "exist" so revoke proceeds
+    mock_redis_apikey.hgetall.return_value = {
+        "name": "test-key",
+        "key_hash": "abc123",
+        "environment": "test",
+        "status": "active",
+        "created_at": "2025-01-01T00:00:00+00:00",
+    }
+    mock_redis_apikey.exists.return_value = True
+
+    await api_key_manager.revoke_key("abc123")
+
+    mock_redis_apikey.pipeline.assert_called()
+    for call in mock_redis_apikey.pipeline.call_args_list:
+        assert call == ((), {"transaction": False}), f"Expected pipeline(transaction=False), got {call}"
+
+
+# ── State Service ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_redis_state():
+    """Mock Redis client for state service tests."""
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=None)
+    client.setex = AsyncMock()
+    client.delete = AsyncMock()
+    client.strlen = AsyncMock(return_value=0)
+    client.ttl = AsyncMock(return_value=-1)
+    client.expire = AsyncMock()
+
+    pipeline_mock = AsyncMock()
+    pipeline_mock.set = MagicMock()
+    pipeline_mock.setex = MagicMock()
+    pipeline_mock.expire = MagicMock()
+    pipeline_mock.execute = AsyncMock(return_value=[True, True, True, True, True])
+    client.pipeline = MagicMock(return_value=pipeline_mock)
+
+    return client
+
+
+@pytest.fixture
+def state_service(mock_redis_state):
+    with patch("src.services.state.redis_pool") as mock_pool:
+        mock_pool.get_client.return_value = mock_redis_state
+        service = StateService(redis_client=mock_redis_state)
+        return service
+
+
+@pytest.mark.asyncio
+async def test_save_state_uses_non_transactional_pipeline(state_service, mock_redis_state):
+    """save_state() must use transaction=False for cluster compat."""
+    import base64
+
+    session_id = "state-test-session"
+    raw_bytes = b"\x02test state data"
+    state_b64 = base64.b64encode(raw_bytes).decode("utf-8")
+
+    await state_service.save_state(session_id, state_b64)
+
+    mock_redis_state.pipeline.assert_called()
+    for call in mock_redis_state.pipeline.call_args_list:
+        assert call == ((), {"transaction": False}), f"Expected pipeline(transaction=False), got {call}"
+
+
+# ── Version resolution ──────────────────────────────────────────────────
+
+
+class TestVersionResolution:
+    """Tests for SERVICE_VERSION env var override."""
+
+    def test_logging_uses_service_version_when_set(self):
+        """add_service_context should prefer settings.service_version."""
+        with (
+            patch("src.utils.logging.settings") as mock_settings,
+            patch("src.utils.logging.__version__", "0.0.0.dev0"),
+        ):
+            mock_settings.service_version = "2.1.4"
+            from src.utils.logging import add_service_context
+
+            event_dict = {}
+            add_service_context(None, None, event_dict)
+
+            assert event_dict["version"] == "2.1.4"
+
+    def test_logging_falls_back_to_build_version(self):
+        """add_service_context should fall back to __version__ when SERVICE_VERSION unset."""
+        with (
+            patch("src.utils.logging.settings") as mock_settings,
+            patch("src.utils.logging.__version__", "1.2.3"),
+        ):
+            mock_settings.service_version = None
+            from src.utils.logging import add_service_context
+
+            event_dict = {}
+            add_service_context(None, None, event_dict)
+
+            assert event_dict["version"] == "1.2.3"

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -26,8 +26,8 @@ def mock_redis():
     pipeline_mock.execute = AsyncMock(return_value=[True, True, True])
     pipeline_mock.reset = AsyncMock()
 
-    # Make pipeline() return the pipeline mock when awaited
-    redis_mock.pipeline = AsyncMock(return_value=pipeline_mock)
+    # Make pipeline() return the pipeline mock (synchronous, like redis.asyncio)
+    redis_mock.pipeline = MagicMock(return_value=pipeline_mock)
     return redis_mock
 
 

--- a/tests/unit/test_settings_validators.py
+++ b/tests/unit/test_settings_validators.py
@@ -3,6 +3,8 @@
 Tests that our Settings class validates configuration values correctly.
 """
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -42,3 +44,125 @@ class TestSeccompProfileTypeValidator:
         """Test that the default seccomp profile type is RuntimeDefault."""
         settings = Settings()
         assert settings.k8s_seccomp_profile_type == "RuntimeDefault"
+
+
+class TestKubernetesPropertyJsonParsing:
+    """Tests for kubernetes property JSON parsing of GKE fields."""
+
+    def test_valid_node_selector_json(self):
+        """Test valid JSON for GKE_SANDBOX_NODE_SELECTOR is parsed."""
+        settings = Settings(gke_sandbox_node_selector='{"pool": "sandbox"}')
+        k8s = settings.kubernetes
+        assert k8s.sandbox_node_selector == {"pool": "sandbox"}
+
+    def test_invalid_node_selector_json_logs_warning(self, caplog):
+        """Test invalid JSON for GKE_SANDBOX_NODE_SELECTOR logs a warning."""
+        settings = Settings(gke_sandbox_node_selector="not-valid-json")
+        with caplog.at_level(logging.WARNING):
+            k8s = settings.kubernetes
+        assert k8s.sandbox_node_selector is None
+        assert "GKE_SANDBOX_NODE_SELECTOR" in caplog.text
+
+    def test_valid_custom_tolerations_json(self):
+        """Test valid JSON for GKE_SANDBOX_CUSTOM_TOLERATIONS is parsed."""
+        settings = Settings(gke_sandbox_custom_tolerations='[{"key": "pool", "value": "sandbox"}]')
+        k8s = settings.kubernetes
+        assert k8s.custom_tolerations == [{"key": "pool", "value": "sandbox"}]
+
+    def test_invalid_custom_tolerations_json_logs_warning(self, caplog):
+        """Test invalid JSON for GKE_SANDBOX_CUSTOM_TOLERATIONS logs a warning."""
+        settings = Settings(gke_sandbox_custom_tolerations="[broken")
+        with caplog.at_level(logging.WARNING):
+            k8s = settings.kubernetes
+        assert k8s.custom_tolerations is None
+        assert "GKE_SANDBOX_CUSTOM_TOLERATIONS" in caplog.text
+
+    def test_image_pull_policy_default_is_always(self):
+        """Test that the default image_pull_policy is 'Always' (matches Settings)."""
+        settings = Settings()
+        k8s = settings.kubernetes
+        assert k8s.image_pull_policy == "Always"
+
+
+class TestRedisPasswordValidator:
+    """Tests for empty-string-to-None password sanitization."""
+
+    def test_empty_password_becomes_none(self):
+        """Empty string REDIS_PASSWORD is converted to None."""
+        settings = Settings(redis_password="")
+        assert settings.redis_password is None
+
+    def test_whitespace_password_becomes_none(self):
+        """Whitespace-only REDIS_PASSWORD is converted to None."""
+        settings = Settings(redis_password="  ")
+        assert settings.redis_password is None
+
+    def test_real_password_preserved(self):
+        """Non-empty password is kept as-is."""
+        settings = Settings(redis_password="s3cret")
+        assert settings.redis_password == "s3cret"
+
+    def test_none_password_stays_none(self):
+        """None password stays None."""
+        settings = Settings(redis_password=None)
+        assert settings.redis_password is None
+
+    def test_empty_sentinel_password_becomes_none(self):
+        """Empty sentinel password is converted to None."""
+        settings = Settings(redis_sentinel_password="")
+        assert settings.redis_sentinel_password is None
+
+
+class TestRedisClusterNodesValidator:
+    """Tests for empty-string-to-None cluster/sentinel node sanitization."""
+
+    def test_empty_cluster_nodes_becomes_none(self):
+        """Empty REDIS_CLUSTER_NODES is converted to None."""
+        settings = Settings(redis_cluster_nodes="")
+        assert settings.redis_cluster_nodes is None
+
+    def test_whitespace_cluster_nodes_becomes_none(self):
+        """Whitespace-only REDIS_CLUSTER_NODES is converted to None."""
+        settings = Settings(redis_cluster_nodes="   ")
+        assert settings.redis_cluster_nodes is None
+
+    def test_real_cluster_nodes_preserved(self):
+        """Valid node list is kept."""
+        settings = Settings(redis_cluster_nodes="node1:7000,node2:7001")
+        assert settings.redis_cluster_nodes == "node1:7000,node2:7001"
+
+    def test_empty_sentinel_nodes_becomes_none(self):
+        """Empty REDIS_SENTINEL_NODES is converted to None."""
+        settings = Settings(redis_sentinel_nodes="")
+        assert settings.redis_sentinel_nodes is None
+
+    def test_real_sentinel_nodes_preserved(self):
+        """Valid sentinel node list is kept."""
+        settings = Settings(redis_sentinel_nodes="sent1:26379,sent2:26379")
+        assert settings.redis_sentinel_nodes == "sent1:26379,sent2:26379"
+
+
+class TestRedisConfigValidators:
+    """Tests for RedisConfig-level validators (password + nodes)."""
+
+    def test_redis_config_empty_password_to_none(self):
+        """RedisConfig also converts empty password to None."""
+        from src.config.redis import RedisConfig
+
+        cfg = RedisConfig(redis_password="")
+        assert cfg.password is None
+
+    def test_redis_config_empty_cluster_nodes_to_none(self):
+        """RedisConfig also converts empty cluster nodes to None."""
+        from src.config.redis import RedisConfig
+
+        cfg = RedisConfig(redis_cluster_nodes="")
+        assert cfg.cluster_nodes is None
+
+    def test_redis_config_real_values_preserved(self):
+        """Non-empty values pass through."""
+        from src.config.redis import RedisConfig
+
+        cfg = RedisConfig(redis_password="pass", redis_cluster_nodes="h:7000")
+        assert cfg.password == "pass"
+        assert cfg.cluster_nodes == "h:7000"


### PR DESCRIPTION
This pull request introduces significant improvements to the Docker sidecar architecture for KubeCodeRun, enabling support for two distinct execution modes: agent-based and legacy nsenter-based. It refactors the Docker build process to produce two separate images, adds a new Go-based executor agent for secure code execution, and updates configuration and CI workflows to support these changes.

**Sidecar architecture and Dockerfile refactor:**

* Refactored `docker/sidecar/Dockerfile` to use multi-target builds, producing two distinct images: `kubecoderun-sidecar-agent` (agent mode, recommended) and `kubecoderun-sidecar-nsenter` (legacy nsenter mode). The agent image includes a statically compiled Go binary for secure code execution without Linux capabilities or privilege escalation, while the nsenter image retains legacy compatibility for clusters that require it. [[1]](diffhunk://#diff-d21392bdd37d30f5d57c835d16f01125b70e29767b34d335e4b4caa570b3b5bcL2-R100) [[2]](diffhunk://#diff-d21392bdd37d30f5d57c835d16f01125b70e29767b34d335e4b4caa570b3b5bcL105-R199)

**Executor agent implementation:**

* Added new Go module `docker/sidecar/executor-agent` with `main.go` implementing a lightweight HTTP server for code execution. This agent allows the sidecar to execute code via HTTP requests inside the main container, inheriting the container's environment and enforcing directory restrictions for security. [[1]](diffhunk://#diff-f1db4f52c3cfa491b380a1c5d6a5bb6a1dc40c991f7197ade4c6da67075bb6a7R1-R3) [[2]](diffhunk://#diff-bf131ce781e6b9b428b1c9cce6b776032df336617c58e53eb591fde49b5e62e0R1-R253)

**CI/CD workflow updates:**

* Modified GitHub Actions workflows to build and publish both sidecar images. The reusable build workflow now accepts a `build_target` input, and the publish workflow separately builds and tags both agent and nsenter images. [[1]](diffhunk://#diff-6ca068ae958191303e61e3fe1c54e8076fd503f48213e5e3189eb73a3a121562R32-R36) [[2]](diffhunk://#diff-6ca068ae958191303e61e3fe1c54e8076fd503f48213e5e3189eb73a3a121562R82) [[3]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L148-R167) [[4]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L347-R364)

**Configuration improvements:**

* Updated `.env.example` with new environment variables for Redis deployment modes (standalone, cluster, sentinel), TLS options, key prefixing, and detailed Kubernetes execution configuration for agent and nsenter modes. These changes improve flexibility and clarity for deployment in various environments. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR35-R36) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR47-R73) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR176-R206)

**Editor and code style consistency:**

* Added a comprehensive `.editorconfig` file to standardize code formatting across languages and file types in the repository.