### PR TITLE
fix: pool replenish issue

### DIFF
--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -72,6 +72,9 @@ class PodPool:
         self._health_check_task: asyncio.Task | None = None
         self._running = False
 
+        # Event to wake up the replenish loop immediately (issue #30)
+        self._replenish_needed = asyncio.Event()
+
     async def _get_http_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
         if self._http_client is None or self._http_client.is_closed:
@@ -304,25 +307,42 @@ class PodPool:
                     error=str(e),
                 )
 
+    def _signal_replenish(self):
+        """Signal that pool replenishment is needed immediately."""
+        self._replenish_needed.set()
+
     async def _replenish_loop(self):
-        """Background task to maintain pool size."""
+        """Background task to maintain pool size.
+
+        Uses an asyncio.Event so that health checks and failed acquires
+        can wake the loop immediately instead of waiting for the next
+        polling interval (fixes issue #30).
+        """
         while self._running:
             try:
-                await asyncio.sleep(5)
+                # Wait for either the event signal or the polling interval
+                try:
+                    await asyncio.wait_for(self._replenish_needed.wait(), timeout=5)
+                except TimeoutError:
+                    pass
+                self._replenish_needed.clear()
 
                 async with self._lock:
                     available_count = sum(1 for p in self._pods.values() if p.is_available)
 
                 if available_count < self.pool_size:
                     needed = self.pool_size - available_count
-                    logger.debug(
+                    logger.info(
                         "Replenishing pool",
                         language=self.language,
                         available=available_count,
                         needed=needed,
                     )
-                    for _ in range(min(needed, 3)):
-                        await self._create_warm_pod()
+                    # Create all needed pods in parallel (batched by 5)
+                    for i in range(0, needed, 5):
+                        batch = min(5, needed - i)
+                        tasks = [self._create_warm_pod() for _ in range(batch)]
+                        await asyncio.gather(*tasks, return_exceptions=True)
 
             except asyncio.CancelledError:
                 break
@@ -343,6 +363,7 @@ class PodPool:
                     pods_to_check = [p for p in self._pods.values() if p.is_available]
 
                 client = await self._get_http_client()
+                removed_any = False
 
                 for pooled_pod in pods_to_check:
                     try:
@@ -369,6 +390,11 @@ class PodPool:
                             if pooled_pod.handle.uid in self._pods:
                                 del self._pods[pooled_pod.handle.uid]
                         await self._delete_pod(pooled_pod.handle)
+                        removed_any = True
+
+                # Trigger immediate replenishment if pods were removed (issue #30)
+                if removed_any:
+                    self._signal_replenish()
 
             except asyncio.CancelledError:
                 break
@@ -389,39 +415,56 @@ class PodPool:
         Returns:
             PodHandle if a pod was acquired, None otherwise
         """
-        try:
-            pod_uid = await asyncio.wait_for(
-                self._available.get(),
-                timeout=timeout,
-            )
-        except TimeoutError:
-            logger.warning(
-                "Timeout acquiring pod from pool",
-                language=self.language,
-                session_id=session_id[:12],
-            )
-            return None
+        deadline = asyncio.get_event_loop().time() + timeout
 
-        async with self._lock:
-            pooled_pod = self._pods.get(pod_uid)
-            if not pooled_pod:
+        while True:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                logger.warning(
+                    "Timeout acquiring pod from pool",
+                    language=self.language,
+                    session_id=session_id[:12],
+                )
+                self._signal_replenish()
                 return None
 
-            pooled_pod.acquired = True
-            pooled_pod.acquired_at = datetime.now(UTC)
-            pooled_pod.handle.status = PodStatus.EXECUTING
-            pooled_pod.handle.session_id = session_id
+            try:
+                pod_uid = await asyncio.wait_for(
+                    self._available.get(),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Timeout acquiring pod from pool",
+                    language=self.language,
+                    session_id=session_id[:12],
+                )
+                self._signal_replenish()
+                return None
 
-            self._session_pods[session_id] = pod_uid
+            async with self._lock:
+                pooled_pod = self._pods.get(pod_uid)
+                if not pooled_pod:
+                    # Stale entry — pod was removed (e.g. by health check).
+                    # Signal replenishment and retry with remaining time.
+                    self._signal_replenish()
+                    continue
 
-            logger.debug(
-                "Acquired pod from pool",
-                pod_name=pooled_pod.handle.name,
-                language=self.language,
-                session_id=session_id[:12],
-            )
+                pooled_pod.acquired = True
+                pooled_pod.acquired_at = datetime.now(UTC)
+                pooled_pod.handle.status = PodStatus.EXECUTING
+                pooled_pod.handle.session_id = session_id
 
-            return pooled_pod.handle
+                self._session_pods[session_id] = pod_uid
+
+                logger.debug(
+                    "Acquired pod from pool",
+                    pod_name=pooled_pod.handle.name,
+                    language=self.language,
+                    session_id=session_id[:12],
+                )
+
+                return pooled_pod.handle
 
     async def release(self, handle: PodHandle, destroy: bool = True):
         """Release a pod back to the pool or destroy it.

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -430,13 +430,25 @@ class TestValidateAll:
         assert result is True
 
     def test_validate_all_with_errors(self):
-        """Test validation with errors."""
+        """Test validation returns False when a real check produces an error."""
         validator = ConfigValidator()
-        validator.errors.append("Test error")
 
-        result = validator.validate_all()
+        # Trigger a real validation error: total file size < individual file size
+        with patch("src.utils.config_validator.settings") as mock_settings:
+            mock_settings.api_key = "valid-key-long-enough"
+            mock_settings.api_keys = []
+            mock_settings.allowed_file_extensions = [".py"]
+            mock_settings.enable_network_isolation = True
+            mock_settings.enable_filesystem_isolation = True
+            mock_settings.max_file_size_mb = 100
+            mock_settings.max_total_file_size_mb = 10  # Less than individual → error
+            mock_settings.api_debug = True
+            mock_settings.pod_pool_enabled = False
+
+            result = validator.validate_all()
 
         assert result is False
+        assert any("Total file size" in e for e in validator.errors)
 
     def test_validate_all_clears_previous(self):
         """Test that validate_all clears previous errors/warnings."""

--- a/tests/unit/test_metrics_collector.py
+++ b/tests/unit/test_metrics_collector.py
@@ -700,8 +700,11 @@ class TestStartRedisConnectionErrors:
         """Test start handles Redis connection timeout."""
         collector = MetricsCollector()
 
-        with patch("src.services.metrics.redis.from_url") as mock_from_url:
-            mock_from_url.side_effect = TimeoutError()
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=TimeoutError())
+
+        with patch("src.core.pool.redis_pool") as mock_pool:
+            mock_pool.get_client.return_value = mock_redis
 
             await collector.start()
 
@@ -713,8 +716,11 @@ class TestStartRedisConnectionErrors:
         """Test start handles Redis generic connection error."""
         collector = MetricsCollector()
 
-        with patch("src.services.metrics.redis.from_url") as mock_from_url:
-            mock_from_url.side_effect = Exception("Connection refused")
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with patch("src.core.pool.redis_pool") as mock_pool:
+            mock_pool.get_client.return_value = mock_redis
 
             await collector.start()
 

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -837,11 +837,12 @@ class TestPodPoolReplenishLoop:
             return None
 
         with patch.object(pod_pool, "_create_warm_pod", side_effect=mock_create):
-            with patch("asyncio.sleep", new_callable=AsyncMock):
-                try:
-                    await asyncio.wait_for(pod_pool._replenish_loop(), timeout=1)
-                except TimeoutError:
-                    pass
+            # Signal the event to wake the loop immediately
+            pod_pool._signal_replenish()
+            try:
+                await asyncio.wait_for(pod_pool._replenish_loop(), timeout=2)
+            except TimeoutError:
+                pod_pool._running = False
 
         assert call_count > 0
 
@@ -849,33 +850,35 @@ class TestPodPoolReplenishLoop:
     async def test_replenish_loop_handles_exception(self, pod_pool):
         """Test replenish loop handles exception gracefully."""
         pod_pool._running = True
-        iteration = 0
-
-        async def mock_sleep(_):
-            nonlocal iteration
-            iteration += 1
-            if iteration >= 2:
-                pod_pool._running = False
+        call_count = 0
 
         async def mock_create():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                pod_pool._running = False
             raise Exception("Create failed")
 
         with patch.object(pod_pool, "_create_warm_pod", side_effect=mock_create):
-            with patch("asyncio.sleep", side_effect=mock_sleep):
-                # Should not raise
-                await pod_pool._replenish_loop()
+            pod_pool._signal_replenish()
+            try:
+                await asyncio.wait_for(pod_pool._replenish_loop(), timeout=2)
+            except TimeoutError:
+                pod_pool._running = False
 
     @pytest.mark.asyncio
     async def test_replenish_loop_cancelled_error(self, pod_pool):
         """Test replenish loop handles CancelledError."""
         pod_pool._running = True
 
-        async def mock_sleep(_):
-            raise asyncio.CancelledError()
-
-        with patch("asyncio.sleep", side_effect=mock_sleep):
-            # Should break out of loop on CancelledError
-            await pod_pool._replenish_loop()
+        # Start the loop and cancel it
+        task = asyncio.create_task(pod_pool._replenish_loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 class TestPodPoolHealthCheckLoop:

--- a/tests/unit/test_pool_replenishment.py
+++ b/tests/unit/test_pool_replenishment.py
@@ -1,0 +1,268 @@
+"""Tests for immediate pool replenishment (GitHub issue #30).
+
+When all pool pods are terminated externally, the pool should replenish
+immediately rather than waiting for the next polling interval.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.kubernetes.models import (
+    PodHandle,
+    PodStatus,
+    PoolConfig,
+    PooledPod,
+)
+from src.services.kubernetes.pool import PodPool
+
+
+@pytest.fixture
+def pool_config():
+    return PoolConfig(
+        language="python",
+        image="python:3.11",
+        pool_size=3,
+        sidecar_image="sidecar:latest",
+    )
+
+
+@pytest.fixture
+def pod_pool(pool_config):
+    with patch("src.services.kubernetes.pool.get_current_namespace", return_value="test-ns"):
+        pool = PodPool(pool_config, namespace="test-ns")
+        return pool
+
+
+def _make_pooled_pod(uid, language="python"):
+    handle = PodHandle(
+        name=f"pool-{language}-{uid}",
+        namespace="test-ns",
+        uid=uid,
+        language=language,
+        status=PodStatus.WARM,
+        labels={},
+    )
+    handle.pod_ip = "10.0.0.1"
+    return PooledPod(handle=handle, language=language)
+
+
+class TestReplenishEvent:
+    """Tests for the _replenish_needed event mechanism."""
+
+    def test_signal_replenish_sets_event(self, pod_pool):
+        """Test that _signal_replenish sets the event."""
+        assert not pod_pool._replenish_needed.is_set()
+        pod_pool._signal_replenish()
+        assert pod_pool._replenish_needed.is_set()
+
+    @pytest.mark.asyncio
+    async def test_replenish_loop_wakes_on_event(self, pod_pool):
+        """Test that the replenish loop wakes immediately when event is signaled."""
+        pod_pool._running = True
+        replenish_called = asyncio.Event()
+
+        async def mock_create():
+            replenish_called.set()
+            pod_pool._running = False
+            return None
+
+        with patch.object(pod_pool, "_create_warm_pod", side_effect=mock_create):
+            # Start the loop
+            loop_task = asyncio.create_task(pod_pool._replenish_loop())
+
+            # Signal replenishment immediately
+            pod_pool._signal_replenish()
+
+            # The loop should wake up and call _create_warm_pod within <1s
+            try:
+                await asyncio.wait_for(replenish_called.wait(), timeout=1.0)
+            except TimeoutError:
+                pod_pool._running = False
+                pytest.fail("Replenish loop did not wake up within 1 second")
+            finally:
+                pod_pool._running = False
+                loop_task.cancel()
+                try:
+                    await loop_task
+                except asyncio.CancelledError:
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_replenish_loop_creates_all_needed_pods(self, pod_pool):
+        """Test that replenish creates all needed pods, not just 3."""
+        pod_pool._running = True
+        create_count = 0
+
+        async def mock_create():
+            nonlocal create_count
+            create_count += 1
+            # Stop after first batch
+            if create_count >= pod_pool.pool_size:
+                pod_pool._running = False
+            return None
+
+        with patch.object(pod_pool, "_create_warm_pod", side_effect=mock_create):
+            pod_pool._signal_replenish()
+            try:
+                await asyncio.wait_for(pod_pool._replenish_loop(), timeout=2.0)
+            except TimeoutError:
+                pod_pool._running = False
+
+        # Should have tried to create pool_size (3) pods, not just 3 max
+        assert create_count == pod_pool.pool_size
+
+
+class TestAcquireTriggersReplenish:
+    """Tests for acquire triggering replenishment."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_stale_pod_signals_replenish(self, pod_pool):
+        """When acquire gets a stale UID (pod removed by health check),
+        it should signal replenishment and retry."""
+        # Put a stale UID in the queue (not in _pods)
+        await pod_pool._available.put("stale-uid")
+
+        # Also put a valid pod
+        valid_pod = _make_pooled_pod("valid-uid")
+        pod_pool._pods["valid-uid"] = valid_pod
+        await pod_pool._available.put("valid-uid")
+
+        result = await pod_pool.acquire("session-123", timeout=5)
+
+        # Should have skipped stale and acquired the valid pod
+        assert result is not None
+        assert result.uid == "valid-uid"
+        # Replenish event should have been signaled for the stale entry
+        assert pod_pool._replenish_needed.is_set()
+
+    @pytest.mark.asyncio
+    async def test_acquire_timeout_signals_replenish(self, pod_pool):
+        """When acquire times out, it should signal replenishment."""
+        result = await pod_pool.acquire("session-123", timeout=0.1)
+
+        assert result is None
+        assert pod_pool._replenish_needed.is_set()
+
+    @pytest.mark.asyncio
+    async def test_acquire_retries_past_stale_entries(self, pod_pool):
+        """Acquire should retry past multiple stale entries."""
+        # Put multiple stale UIDs
+        await pod_pool._available.put("stale-1")
+        await pod_pool._available.put("stale-2")
+
+        # Then a valid pod
+        valid_pod = _make_pooled_pod("valid-uid")
+        pod_pool._pods["valid-uid"] = valid_pod
+        await pod_pool._available.put("valid-uid")
+
+        result = await pod_pool.acquire("session-123", timeout=5)
+
+        assert result is not None
+        assert result.uid == "valid-uid"
+
+
+class TestHealthCheckTriggersReplenish:
+    """Tests for health check triggering immediate replenishment."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_signals_replenish_on_removal(self, pod_pool):
+        """When health check removes unhealthy pods, it should signal
+        immediate replenishment."""
+        pod_pool._running = True
+        pooled_pod = _make_pooled_pod("unhealthy-uid")
+        pooled_pod.health_check_failures = 2  # One more failure triggers removal
+        pod_pool._pods["unhealthy-uid"] = pooled_pod
+        iteration = 0
+
+        async def mock_sleep(_):
+            nonlocal iteration
+            iteration += 1
+            if iteration >= 2:
+                pod_pool._running = False
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500  # Unhealthy
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
+            with patch.object(pod_pool, "_delete_pod", new_callable=AsyncMock):
+                with patch("asyncio.sleep", side_effect=mock_sleep):
+                    await pod_pool._health_check_loop()
+
+        # Pod should have been removed
+        assert "unhealthy-uid" not in pod_pool._pods
+        # Replenish should have been signaled
+        assert pod_pool._replenish_needed.is_set()
+
+    @pytest.mark.asyncio
+    async def test_health_check_no_signal_when_all_healthy(self, pod_pool):
+        """Health check should NOT signal replenish when all pods are healthy."""
+        pod_pool._running = True
+        pooled_pod = _make_pooled_pod("healthy-uid")
+        pod_pool._pods["healthy-uid"] = pooled_pod
+        iteration = 0
+
+        async def mock_sleep(_):
+            nonlocal iteration
+            iteration += 1
+            if iteration >= 2:
+                pod_pool._running = False
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200  # Healthy
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
+            with patch("asyncio.sleep", side_effect=mock_sleep):
+                await pod_pool._health_check_loop()
+
+        # Replenish should NOT have been signaled
+        assert not pod_pool._replenish_needed.is_set()
+
+
+class TestEndToEndPoolRecovery:
+    """End-to-end test simulating the issue #30 scenario."""
+
+    @pytest.mark.asyncio
+    async def test_pool_recovers_after_all_pods_terminated(self, pod_pool):
+        """Simulate: all pods terminated externally, health check detects,
+        replenish loop creates replacements immediately."""
+        # Set up pool with pods
+        pod1 = _make_pooled_pod("pod-1")
+        pod2 = _make_pooled_pod("pod-2")
+        pod3 = _make_pooled_pod("pod-3")
+        pod_pool._pods = {"pod-1": pod1, "pod-2": pod2, "pod-3": pod3}
+
+        # Simulate health check removing all pods (they were terminated externally)
+        for uid in list(pod_pool._pods.keys()):
+            del pod_pool._pods[uid]
+
+        # Signal replenish (as health check would)
+        pod_pool._signal_replenish()
+
+        # Verify the event is set for immediate wakeup
+        assert pod_pool._replenish_needed.is_set()
+
+        # Verify replenish loop would create 3 pods (pool_size)
+        pod_pool._running = True
+        create_count = 0
+
+        async def mock_create():
+            nonlocal create_count
+            create_count += 1
+            if create_count >= 3:
+                pod_pool._running = False
+            return None
+
+        with patch.object(pod_pool, "_create_warm_pod", side_effect=mock_create):
+            try:
+                await asyncio.wait_for(pod_pool._replenish_loop(), timeout=2.0)
+            except TimeoutError:
+                pod_pool._running = False
+
+        assert create_count == 3


### PR DESCRIPTION
## Summary

Fixes #30 — when all pool pods are terminated externally, the pool now replenishes immediately instead of slowly over several minutes.

### Root Cause

Three issues in `PodPool` caused slow recovery:

1. **Sleep-first polling** — `_replenish_loop` always slept 5s before checking pool state
2. **Batch limit of 3** — only created 3 pods per cycle, requiring multiple cycles for larger pools
3. **No immediate wakeup** — health check removed dead pods but the replenish loop had no way to know until its next 5s poll; worst case ~90s before recovery started (30s health check interval × 3 failure threshold)

### Changes

**1. Event-based replenishment** (`src/services/kubernetes/pool.py`)
- Added `asyncio.Event` (`_replenish_needed`) with `_signal_replenish()` helper
- `_replenish_loop` now uses `wait_for(event.wait(), timeout=5)` — wakes instantly on signal, falls back to 5s polling
- Creates all needed pods in parallel (batched by 5) instead of max 3 sequentially

**2. Health check triggers immediate replenish**
- After removing unhealthy pods, `_health_check_loop` now calls `_signal_replenish()` to wake the replenish loop immediately

**3. Acquire retries and signals**
- `acquire()` now retries past stale queue entries (pods removed by health check but still in queue) instead of returning None on the first stale hit
- Signals replenishment on both timeout and stale pod encounters

**4. Pre-existing test fixes**
- `test_config_validator.py` — test pre-appended errors that `validate_all()` clears; fixed to trigger real validation error via invalid settings
- `test_metrics_collector.py` — patched wrong import path (`redis.from_url` vs `redis_pool.get_client()`); fixed patch target
- `test_pool.py` — updated 3 replenish loop tests to work with event-based wakeup

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

9 new unit tests in `tests/unit/test_pool_replenishment.py`:

- [x] `test_signal_replenish_sets_event` — event mechanism works
- [x] `test_replenish_loop_wakes_on_event` — loop wakes within <1s when signaled (vs 5s polling)
- [x] `test_replenish_loop_creates_all_needed_pods` — creates full pool_size, not capped at 3
- [x] `test_acquire_stale_pod_signals_replenish` — acquire skips stale entries and signals replenish
- [x] `test_acquire_timeout_signals_replenish` — timeout triggers replenish
- [x] `test_acquire_retries_past_stale_entries` — retries through multiple stale entries
- [x] `test_health_check_signals_replenish_on_removal` — health check wakes replenish loop
- [x] `test_health_check_no_signal_when_all_healthy` — no false signals
- [x] `test_pool_recovers_after_all_pods_terminated` — end-to-end recovery scenario

All 1321 unit tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes