### PR TITLE
feat: imagePullSecrets support for execution pods in Kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,13 +61,32 @@ docs/
 *.md
 !README.md
 
-# Docker
-Dockerfile*
+# Docker (language images not needed in API image)
+docker/python.Dockerfile
+docker/nodejs.Dockerfile
+docker/go.Dockerfile
+docker/java.Dockerfile
+docker/c-cpp.Dockerfile
+docker/rust.Dockerfile
+docker/php.Dockerfile
+docker/r.Dockerfile
+docker/fortran.Dockerfile
+docker/d.Dockerfile
+docker/runner/
+docker/requirements/
+docker/scripts/
+docker/.dockerignore
 docker-compose*.yml
 .dockerignore
 
-# Deployment
-deploy.sh
+# Helm / deployment
+helm-deployments/
+
+# Scripts (not needed in API image)
+scripts/
+
+# Tests
+tests/
 
 # Data directories
 data/
@@ -79,4 +98,15 @@ node_modules/
 
 # Temporary files
 *.tmp
+
+# Misc
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+justfile
+ruff.toml
+ty.toml
 *.temp

--- a/.env.example
+++ b/.env.example
@@ -72,16 +72,26 @@ MINIO_SECRET_KEY=minioadmin
 MINIO_SECURE=false
 MINIO_BUCKET=kubecoderun-files
 MINIO_REGION=us-east-1
+# MINIO_USE_IAM=false  # Use IAM authentication (for AWS S3/IRSA)
 
-# Docker Configuration
-DOCKER_IMAGE_REGISTRY=kubecoderun
-# DOCKER_BASE_URL=unix://var/run/docker.sock
-DOCKER_TIMEOUT=60
-DOCKER_NETWORK_MODE=none
-DOCKER_READ_ONLY=true
+# Kubernetes Configuration
+K8S_IMAGE_REGISTRY=aronmuon/kubecoderun
+K8S_IMAGE_TAG=latest
+K8S_IMAGE_PULL_POLICY=Always
+# K8S_IMAGE_PULL_SECRETS=  # Comma-separated secret names for private registries (e.g., docker-privaterepo,another-secret)
+# K8S_NAMESPACE=  # Defaults to API's namespace
+# K8S_SERVICE_ACCOUNT=kubecoderun-executor
+# K8S_CPU_LIMIT=1
+# K8S_MEMORY_LIMIT=512Mi
+# K8S_CPU_REQUEST=100m
+# K8S_MEMORY_REQUEST=128Mi
+# K8S_RUN_AS_USER=65532
+# K8S_SECCOMP_PROFILE_TYPE=RuntimeDefault
+# K8S_JOB_TTL_SECONDS=60
+# K8S_JOB_DEADLINE_SECONDS=300
 
 # Resource Limits - Execution
-MAX_EXECUTION_TIME=120
+MAX_EXECUTION_TIME=30
 MAX_MEMORY_MB=512
 MAX_CPUS=1
 MAX_CPU_QUOTA=50000 #Deprecated
@@ -103,16 +113,18 @@ MAX_SESSIONS_PER_ENTITY=100
 # TTL applies only to MinIO-stored session data (files/metadata). Containers are ephemeral per execution.
 # 0 = no expiry (infinite). Max 8760 (1 year).
 SESSION_TTL_HOURS=0
-SESSION_CLEANUP_INTERVAL_MINUTES=60
+SESSION_CLEANUP_INTERVAL_MINUTES=10
 SESSION_ID_LENGTH=32
 
 # MinIO Orphan Cleanup (optional)
 # Enable periodic pruning of MinIO objects older than TTL with missing Redis sessions
-ENABLE_ORPHAN_MINIO_CLEANUP=true
+# ENABLE_ORPHAN_MINIO_CLEANUP=false
 
 # Pod Pool Configuration
 POD_POOL_ENABLED=true
 POD_POOL_WARMUP_ON_STARTUP=true
+# POD_TTL_MINUTES=5
+# POD_CLEANUP_INTERVAL_MINUTES=5
 
 # Per-language pool sizes (0 = on-demand only, no pre-warming)
 # Only set the languages you want to pre-warm
@@ -164,6 +176,17 @@ METRICS_ARCHIVE_ENABLED=true
 # Keep archived metrics for this many days
 METRICS_ARCHIVE_RETENTION_DAYS=90
 
+# SQLite Metrics (local dashboard metrics)
+# SQLITE_METRICS_ENABLED=true
+# SQLITE_METRICS_DB_PATH=data/metrics.db
+# METRICS_EXECUTION_RETENTION_DAYS=90
+# METRICS_DAILY_RETENTION_DAYS=365
+# METRICS_AGGREGATION_INTERVAL_MINUTES=60
+
+# Pod Hardening
+# POD_MASK_HOST_INFO=true
+# POD_GENERIC_HOSTNAME=sandbox
+
 # Pod Scheduling (for targeting sandboxed node pools)
 # K8S_RUNTIME_CLASS_NAME=gvisor
 # K8S_POD_NODE_SELECTOR={"sandbox":"true"}
@@ -197,4 +220,4 @@ HEALTH_CHECK_TIMEOUT=5
 # Development Configuration
 ENABLE_CORS=false
 # CORS_ORIGINS=http://localhost:3000,http://localhost:8080
-ENABLE_DOCS=false
+ENABLE_DOCS=true

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+.pdm-python
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ config/local.py
 
 # Hatch auto-generated version file
 _version.py
+src/utils/config_validator.py

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,8 +1,10 @@
 # Keep build contexts minimal and deterministic.
 
-# Python artifacts (sidecar)
+# Python artifacts
 __pycache__/
 *.py[cod]
+*$py.class
+*.so
 
 # Editor/OS
 .DS_Store
@@ -13,13 +15,44 @@ Thumbs.db
 
 # Git
 .git/
+.gitignore
 
-# Local env/IDE files (if present)
+# Local env/IDE files
 .env
 .env.*
 .vscode/
 .idea/
 
+# Documentation
+docs/
+*.md
+
+# Tests
+tests/
+*_test.go
+
+# Scripts (not needed in language images, except ts-runner.js used by nodejs image)
+scripts/
+!scripts/ts-runner.js
+
 # Keep sidecar & API code out of language images
 sidecar/
 api/
+
+# Helm / deployment
+helm-deployments/
+
+# Dashboard (not needed in language images)
+dashboard/
+
+# Build artifacts
+htmlcov/
+.coverage
+.pytest_cache/
+*.log
+logs/
+
+# Temporary files
+*.tmp
+data/
+temp/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -241,6 +241,7 @@ POD_POOL_EXHAUSTION_TRIGGER=true   # Trigger immediate replenishment when exhaus
 K8S_NAMESPACE=kubecoderun
 K8S_IMAGE_REGISTRY=aronmuon/kubecoderun
 K8S_IMAGE_TAG=latest
+K8S_IMAGE_PULL_SECRETS=docker-privaterepo  # Comma-separated secret names for private registries
 K8S_CPU_LIMIT=1
 K8S_MEMORY_LIMIT=512Mi
 K8S_CPU_REQUEST=100m

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -177,6 +177,7 @@ Kubernetes is used for secure code execution in isolated pods.
 | `K8S_NAMESPACE`        | `""` (uses API's namespace)                  | Namespace for execution pods             |
 | `K8S_IMAGE_REGISTRY`   | `aronmuon/kubecoderun`              | Registry prefix for language images      |
 | `K8S_IMAGE_TAG`        | `latest`                                     | Image tag for language images            |
+| `K8S_IMAGE_PULL_SECRETS` | `""`                                       | Comma-separated K8s secret names for private registries |
 | `K8S_CPU_LIMIT`        | `1`                                          | CPU limit per execution pod              |
 | `K8S_MEMORY_LIMIT`     | `512Mi`                                      | Memory limit per execution pod           |
 | `K8S_CPU_REQUEST`      | `100m`                                       | CPU request per execution pod            |

--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
   K8S_IMAGE_REGISTRY: {{ .Values.execution.imageRegistry | quote }}
   K8S_IMAGE_TAG: {{ $imageTag | quote }}
   K8S_IMAGE_PULL_POLICY: {{ .Values.execution.imagePullPolicy | quote }}
+  {{- if .Values.execution.imagePullSecrets }}
+  K8S_IMAGE_PULL_SECRETS: {{ join "," .Values.execution.imagePullSecrets | quote }}
+  {{- end }}
   K8S_CPU_LIMIT: {{ .Values.execution.resources.limits.cpu | quote }}
   K8S_MEMORY_LIMIT: {{ .Values.execution.resources.limits.memory | quote }}
   K8S_CPU_REQUEST: {{ .Values.execution.resources.requests.cpu | quote }}

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -198,6 +198,10 @@ execution:
   imageTag: ""
   # Image pull policy for execution pods (IfNotPresent, Always, Never)
   imagePullPolicy: "IfNotPresent"
+  # Image pull secrets for execution pods (for private registries)
+  # These are applied to dynamically created execution pods/jobs, not the API deployment.
+  # Example: ["docker-privaterepo", "another-secret"]
+  imagePullSecrets: []
 
   # Service account for execution pods (with pod/job create permissions)
   serviceAccount:

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -185,10 +185,17 @@ build_image() {
 
     local build_output
     local exit_code=0
+    local build_date
+    build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local vcs_ref
+    vcs_ref=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
     # shellcheck disable=SC2086
     build_output=$(docker build \
         $NO_CACHE \
+        --build-arg VERSION="$TAG" \
+        --build-arg BUILD_DATE="$build_date" \
+        --build-arg VCS_REF="$vcs_ref" \
         -t "$full_name" \
         -f "$DOCKER_DIR/$dockerfile" \
         "$context_path" 2>&1) || exit_code=$?
@@ -271,9 +278,16 @@ build_single_image() {
             echo ""
 
             # Build with output directly to terminal
+            local build_date
+            build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            local vcs_ref
+            vcs_ref=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
             # shellcheck disable=SC2086
             docker build \
                 $NO_CACHE \
+                --build-arg VERSION="$TAG" \
+                --build-arg BUILD_DATE="$build_date" \
+                --build-arg VCS_REF="$vcs_ref" \
                 -t "$full_name" \
                 -f "$DOCKER_DIR/$dockerfile" \
                 "$context_path"

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -163,6 +163,10 @@ class Settings(BaseSettings):
         default="Always",
         description="Image pull policy for execution pods (Always, IfNotPresent, Never)",
     )
+    k8s_image_pull_secrets: str = Field(
+        default="",
+        description="Comma-separated list of Kubernetes secret names for pulling execution pod images from private registries",
+    )
     k8s_runtime_class_name: str = Field(
         default="",
         description="RuntimeClassName for execution pods (e.g. gvisor, kata). Empty = cluster default.",
@@ -654,6 +658,7 @@ class Settings(BaseSettings):
                     runtime_class_name=self.k8s_runtime_class_name,
                     pod_node_selector=self.k8s_pod_node_selector,
                     pod_tolerations=self.k8s_pod_tolerations,
+                    image_pull_secrets=self.k8s_image_pull_secrets,
                 )
             )
 
@@ -672,11 +677,17 @@ class Settings(BaseSettings):
         return Path(self.ssl_cert_file).exists() and Path(self.ssl_key_file).exists()
 
     def get_redis_url(self) -> str:
-        """Get Redis connection URL."""
+        """Get Redis connection URL.
+
+        Returns a ``rediss://`` URL when SSL is enabled so that redis-py 7.x
+        selects ``SSLConnection`` automatically (the ``ssl=True`` kwarg is no
+        longer accepted by ``AbstractConnection.__init__()``).
+        """
         if self.redis_url:
             return self.redis_url
+        scheme = "rediss" if self.redis_ssl else "redis"
         password_part = f":{self.redis_password}@" if self.redis_password else ""
-        return f"redis://{password_part}{self.redis_host}:{self.redis_port}/{self.redis_db}"
+        return f"{scheme}://{password_part}{self.redis_host}:{self.redis_port}/{self.redis_db}"
 
     def get_valid_api_keys(self) -> list[str]:
         """Get all valid API keys including the primary key."""

--- a/src/config/redis.py
+++ b/src/config/redis.py
@@ -68,18 +68,30 @@ class RedisConfig(BaseSettings):
     sentinel_db: int = Field(default=0, alias="redis_sentinel_db")
 
     def get_url(self) -> str:
-        """Get Redis connection URL."""
+        """Get Redis connection URL.
+
+        Returns a ``rediss://`` URL when SSL is enabled so that redis-py 7.x
+        selects ``SSLConnection`` automatically (the ``ssl=True`` kwarg is no
+        longer accepted by ``AbstractConnection.__init__()``).
+        """
         if self.url:
             return self.url
+        scheme = "rediss" if self.ssl else "redis"
         password_part = f":{self.password}@" if self.password else ""
-        return f"redis://{password_part}{self.host}:{self.port}/{self.db}"
+        return f"{scheme}://{password_part}{self.host}:{self.port}/{self.db}"
 
     def get_ssl_kwargs(self) -> dict:
-        """Get SSL kwargs for Redis client creation."""
+        """Get SSL kwargs for Redis client creation.
+
+        Note: In redis-py 7.x the ``ssl=True`` keyword is no longer accepted by
+        ``AbstractConnection.__init__()``.  SSL is instead enabled by using the
+        ``rediss://`` URL scheme (see ``get_url()``).  The ssl_* parameters below
+        are still accepted by ``SSLConnection`` which is automatically selected
+        when the ``rediss://`` scheme is used.
+        """
         if not self.ssl:
             return {}
         return {
-            "ssl": True,
             "ssl_ca_certs": self.ssl_ca_certs,
             "ssl_certfile": self.ssl_certfile,
             "ssl_keyfile": self.ssl_keyfile,

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -63,6 +63,7 @@ class RedisPool:
                         max_connections=cfg.max_connections,
                         socket_timeout=float(cfg.socket_timeout),
                         socket_connect_timeout=float(cfg.socket_connect_timeout),
+                        ssl=cfg.ssl,
                         **ssl_kwargs,
                     )
                 else:

--- a/src/core/pool.py
+++ b/src/core/pool.py
@@ -63,7 +63,6 @@ class RedisPool:
                         max_connections=cfg.max_connections,
                         socket_timeout=float(cfg.socket_timeout),
                         socket_connect_timeout=float(cfg.socket_connect_timeout),
-                        ssl=cfg.ssl,
                         **ssl_kwargs,
                     )
                 else:

--- a/src/main.py
+++ b/src/main.py
@@ -155,6 +155,7 @@ async def lifespan(app: FastAPI):
                 runtime_class_name=settings.k8s_runtime_class_name,
                 pod_node_selector=settings.k8s_pod_node_selector,
                 pod_tolerations=settings.k8s_pod_tolerations,
+                image_pull_secrets=settings.k8s_image_pull_secrets,
             )
 
             await kubernetes_manager.start()

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -299,10 +299,9 @@ def create_pod_manifest(
         node_selector=node_selector,
         tolerations=tolerations,
         image_pull_secrets=[
-            client.V1LocalObjectReference(name=s.strip())
-            for s in image_pull_secrets.split(",")
-            if s.strip()
-        ] or None,
+            client.V1LocalObjectReference(name=s.strip()) for s in image_pull_secrets.split(",") if s.strip()
+        ]
+        or None,
     )
 
     # Pod metadata

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -191,6 +191,7 @@ def create_pod_manifest(
     runtime_class_name: str = "",
     pod_node_selector: str = "",
     pod_tolerations: str = "",
+    image_pull_secrets: str = "",
 ) -> client.V1Pod:
     """Create a Pod manifest for code execution.
 
@@ -297,6 +298,11 @@ def create_pod_manifest(
         runtime_class_name=runtime_class_name or None,
         node_selector=node_selector,
         tolerations=tolerations,
+        image_pull_secrets=[
+            client.V1LocalObjectReference(name=s.strip())
+            for s in image_pull_secrets.split(",")
+            if s.strip()
+        ] or None,
     )
 
     # Pod metadata

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -214,6 +214,10 @@ def create_pod_manifest(
         image_pull_policy: Image pull policy
         seccomp_profile_type: Seccomp profile type (RuntimeDefault or Unconfined)
         network_isolated: Whether to disable network-dependent features
+        runtime_class_name: Optional RuntimeClassName for pod sandboxing (e.g. gvisor, kata)
+        pod_node_selector: JSON-encoded node selector labels
+        pod_tolerations: JSON-encoded list of tolerations
+        image_pull_secrets: Comma-separated secret names for pulling from private registries
 
     Returns:
         V1Pod manifest ready for creation.

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -120,6 +120,7 @@ class JobExecutor:
             runtime_class_name=spec.runtime_class_name,
             pod_node_selector=spec.pod_node_selector,
             pod_tolerations=spec.pod_tolerations,
+            image_pull_secrets=spec.image_pull_secrets,
             ttl_seconds_after_finished=self.ttl_seconds_after_finished,
             active_deadline_seconds=self.active_deadline_seconds,
         )

--- a/src/services/kubernetes/manager.py
+++ b/src/services/kubernetes/manager.py
@@ -50,6 +50,7 @@ class KubernetesManager:
         runtime_class_name: str = "",
         pod_node_selector: str = "",
         pod_tolerations: str = "",
+        image_pull_secrets: str = "",
     ):
         """Initialize the Kubernetes manager.
 
@@ -76,6 +77,7 @@ class KubernetesManager:
         self.runtime_class_name = runtime_class_name
         self.pod_node_selector = pod_node_selector
         self.pod_tolerations = pod_tolerations
+        self.image_pull_secrets = image_pull_secrets
 
         # Pool manager for warm pods
         self._pool_manager = PodPoolManager(
@@ -287,6 +289,7 @@ class KubernetesManager:
                 runtime_class_name=self.runtime_class_name,
                 pod_node_selector=self.pod_node_selector,
                 pod_tolerations=self.pod_tolerations,
+                image_pull_secrets=self.image_pull_secrets,
             )
 
             result = await self._job_executor.execute_with_job(

--- a/src/services/kubernetes/models.py
+++ b/src/services/kubernetes/models.py
@@ -123,6 +123,9 @@ class PodSpec:
     pod_node_selector: str = ""  # JSON-encoded dict
     pod_tolerations: str = ""  # JSON-encoded list
 
+    # Image pull secrets for private registries
+    image_pull_secrets: str = ""  # Comma-separated secret names
+
 
 @dataclass
 class PoolConfig:
@@ -149,6 +152,9 @@ class PoolConfig:
     runtime_class_name: str = ""
     pod_node_selector: str = ""  # JSON-encoded dict
     pod_tolerations: str = ""  # JSON-encoded list
+
+    # Image pull secrets for private registries
+    image_pull_secrets: str = ""  # Comma-separated secret names
 
     @property
     def uses_pool(self) -> bool:

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -189,6 +189,7 @@ class PodPool:
             runtime_class_name=self.config.runtime_class_name,
             pod_node_selector=self.config.pod_node_selector,
             pod_tolerations=self.config.pod_tolerations,
+            image_pull_secrets=self.config.image_pull_secrets,
         )
 
         try:

--- a/src/utils/config_validator.py
+++ b/src/utils/config_validator.py
@@ -113,9 +113,7 @@ class ConfigValidator:
                 else:
                     nodes = settings.redis.parse_nodes(settings.redis_cluster_nodes)
                     if not nodes:
-                        self.errors.append(
-                            "REDIS_CLUSTER_NODES or REDIS_URL required for cluster mode"
-                        )
+                        self.errors.append("REDIS_CLUSTER_NODES or REDIS_URL required for cluster mode")
                         return
                     client = SyncCluster(
                         host=nodes[0][0],

--- a/src/utils/config_validator.py
+++ b/src/utils/config_validator.py
@@ -107,7 +107,6 @@ class ConfigValidator:
                         settings.redis.url,
                         decode_responses=True,
                         socket_timeout=settings.redis_socket_timeout,
-                        ssl=settings.redis.ssl,
                         **ssl_kwargs,
                     )
                 else:
@@ -120,7 +119,6 @@ class ConfigValidator:
                         port=nodes[0][1],
                         decode_responses=True,
                         socket_timeout=settings.redis_socket_timeout,
-                        ssl=settings.redis.ssl,
                         **ssl_kwargs,
                     )
                 client.ping()

--- a/src/utils/config_validator.py
+++ b/src/utils/config_validator.py
@@ -102,17 +102,29 @@ class ConfigValidator:
             if mode == "cluster":
                 from redis.cluster import RedisCluster as SyncCluster
 
-                nodes = settings.redis.parse_nodes(settings.redis_cluster_nodes)
-                if not nodes:
-                    self.errors.append("REDIS_CLUSTER_NODES required for cluster mode")
-                    return
-                client = SyncCluster(
-                    host=nodes[0][0],
-                    port=nodes[0][1],
-                    decode_responses=True,
-                    socket_timeout=settings.redis_socket_timeout,
-                    **ssl_kwargs,
-                )
+                if settings.redis.url:
+                    client = SyncCluster.from_url(
+                        settings.redis.url,
+                        decode_responses=True,
+                        socket_timeout=settings.redis_socket_timeout,
+                        ssl=settings.redis.ssl,
+                        **ssl_kwargs,
+                    )
+                else:
+                    nodes = settings.redis.parse_nodes(settings.redis_cluster_nodes)
+                    if not nodes:
+                        self.errors.append(
+                            "REDIS_CLUSTER_NODES or REDIS_URL required for cluster mode"
+                        )
+                        return
+                    client = SyncCluster(
+                        host=nodes[0][0],
+                        port=nodes[0][1],
+                        decode_responses=True,
+                        socket_timeout=settings.redis_socket_timeout,
+                        ssl=settings.redis.ssl,
+                        **ssl_kwargs,
+                    )
                 client.ping()
                 client.close()
             elif mode == "sentinel":

--- a/tests/unit/test_kubernetes_client.py
+++ b/tests/unit/test_kubernetes_client.py
@@ -464,3 +464,76 @@ class TestCreatePodManifest:
 
         main_container = pod.spec.containers[0]
         assert main_container.env is None
+
+    def test_create_pod_manifest_no_image_pull_secrets_by_default(self):
+        """Test pod manifest has no imagePullSecrets by default."""
+        pod = client.create_pod_manifest(
+            name="test-pod",
+            namespace="test-ns",
+            main_image="python:3.12",
+            language="python",
+            labels={"app": "test"},
+        )
+
+        assert pod.spec.image_pull_secrets is None
+
+    def test_create_pod_manifest_single_image_pull_secret(self):
+        """Test pod manifest with a single imagePullSecret."""
+        pod = client.create_pod_manifest(
+            name="test-pod",
+            namespace="test-ns",
+            main_image="python:3.12",
+            language="python",
+            labels={"app": "test"},
+            image_pull_secrets="docker-privaterepo",
+        )
+
+        assert pod.spec.image_pull_secrets is not None
+        assert len(pod.spec.image_pull_secrets) == 1
+        assert pod.spec.image_pull_secrets[0].name == "docker-privaterepo"
+
+    def test_create_pod_manifest_multiple_image_pull_secrets(self):
+        """Test pod manifest with multiple comma-separated imagePullSecrets."""
+        pod = client.create_pod_manifest(
+            name="test-pod",
+            namespace="test-ns",
+            main_image="python:3.12",
+            language="python",
+            labels={"app": "test"},
+            image_pull_secrets="docker-privaterepo,ghcr-secret,ecr-creds",
+        )
+
+        assert pod.spec.image_pull_secrets is not None
+        assert len(pod.spec.image_pull_secrets) == 3
+        assert pod.spec.image_pull_secrets[0].name == "docker-privaterepo"
+        assert pod.spec.image_pull_secrets[1].name == "ghcr-secret"
+        assert pod.spec.image_pull_secrets[2].name == "ecr-creds"
+
+    def test_create_pod_manifest_image_pull_secrets_trims_whitespace(self):
+        """Test that whitespace in image pull secrets is trimmed."""
+        pod = client.create_pod_manifest(
+            name="test-pod",
+            namespace="test-ns",
+            main_image="python:3.12",
+            language="python",
+            labels={"app": "test"},
+            image_pull_secrets=" docker-privaterepo , ghcr-secret ",
+        )
+
+        assert pod.spec.image_pull_secrets is not None
+        assert len(pod.spec.image_pull_secrets) == 2
+        assert pod.spec.image_pull_secrets[0].name == "docker-privaterepo"
+        assert pod.spec.image_pull_secrets[1].name == "ghcr-secret"
+
+    def test_create_pod_manifest_empty_image_pull_secrets(self):
+        """Test that empty string results in no imagePullSecrets."""
+        pod = client.create_pod_manifest(
+            name="test-pod",
+            namespace="test-ns",
+            main_image="python:3.12",
+            language="python",
+            labels={"app": "test"},
+            image_pull_secrets="",
+        )
+
+        assert pod.spec.image_pull_secrets is None


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the project, focusing on Kubernetes support for private container registries, improved Docker and build script hygiene, and enhancements to Redis SSL configuration. The most significant changes add support for specifying Kubernetes image pull secrets for execution pods, update build scripts to include metadata, and clarify configuration options.

**Kubernetes and Execution Pod Improvements:**

* Added support for specifying `K8S_IMAGE_PULL_SECRETS` (comma-separated Kubernetes secret names) for private container registries in both configuration files (`.env.example`, `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`, Helm chart, and application code) and propagated this setting through all relevant code paths for pod/job creation. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL75-R94) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R244) [[3]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409R180) [[4]](diffhunk://#diff-27b3911f4fce9e5282966e54963a753ad24677d92cf652a66e566cd94a9726b2R32-R34) [[5]](diffhunk://#diff-01933ba607e0400e8b8098369f01e2f179f98de2bf1d70e9a733a1316905cee2R201-R204) [[6]](diffhunk://#diff-1f6aa9753416b54cc02a01cc97375e445abeb56c8c6dd07aebb681d07d9ffdbaR166-R169) [[7]](diffhunk://#diff-1f6aa9753416b54cc02a01cc97375e445abeb56c8c6dd07aebb681d07d9ffdbaR661) [[8]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R158) [[9]](diffhunk://#diff-6e320ed370f8d0231be14b134b0779f7518c43188d2fd3101cf872617df0a3b3R194) [[10]](diffhunk://#diff-6e320ed370f8d0231be14b134b0779f7518c43188d2fd3101cf872617df0a3b3R301-R305) [[11]](diffhunk://#diff-12e23e2ca7604991a60267aca818f8c404610cfee276d28e1ebaa7f412bc8a44R123) [[12]](diffhunk://#diff-6f32805292de07e769571d998f88f78e66a42f6f6fc4b0d37f347acaba8b03a1R53) [[13]](diffhunk://#diff-6f32805292de07e769571d998f88f78e66a42f6f6fc4b0d37f347acaba8b03a1R80) [[14]](diffhunk://#diff-6f32805292de07e769571d998f88f78e66a42f6f6fc4b0d37f347acaba8b03a1R292) [[15]](diffhunk://#diff-0e68106d4505ca8c5548543bc1813e7c2d3c5789b62abb963b916b29a05b1e15R126-R128) [[16]](diffhunk://#diff-0e68106d4505ca8c5548543bc1813e7c2d3c5789b62abb963b916b29a05b1e15R156-R158) [[17]](diffhunk://#diff-8a22a8effb05a719e0d3fb40a3a56aff23715fb9b0723c38c2f92db9236fda7dR192)
* Updated Helm templates and values to support `imagePullSecrets` for execution pods, allowing for private registry authentication. [[1]](diffhunk://#diff-27b3911f4fce9e5282966e54963a753ad24677d92cf652a66e566cd94a9726b2R32-R34) [[2]](diffhunk://#diff-01933ba607e0400e8b8098369f01e2f179f98de2bf1d70e9a733a1316905cee2R201-R204)

**Configuration and Documentation:**

* Updated `.env.example` with new and reorganized Kubernetes, resource, and pod pool settings. Improved documentation for new and existing configuration options. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL75-R94) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL106-R127) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR179-R189) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL200-R223)
* Clarified and added documentation for new settings in `docs/CONFIGURATION.md` and `docs/ARCHITECTURE.md`. [[1]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409R180) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R244)

**Docker and Build Process:**

* Refined `.dockerignore` files and added new rules to ensure only necessary files are included in Docker build contexts, reducing image size and potential leaks. [[1]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5L64-R89) [[2]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R101-R111) [[3]](diffhunk://#diff-39a2532e7e2a0cc9579bf9828a36a37308c83ba0d1c1c9e7450e0fa354c2dc45L3-R7) [[4]](diffhunk://#diff-39a2532e7e2a0cc9579bf9828a36a37308c83ba0d1c1c9e7450e0fa354c2dc45R18-R58)
* Enhanced `build-images.sh` to inject `VERSION`, `BUILD_DATE`, and `VCS_REF` as build arguments, improving traceability of built images. [[1]](diffhunk://#diff-9fc5e79c3985707d0a5af43380cb69de6721565a1fd35740b83bec5d6a5c642aR188-R198) [[2]](diffhunk://#diff-9fc5e79c3985707d0a5af43380cb69de6721565a1fd35740b83bec5d6a5c642aR281-R290)

**Redis SSL Configuration:**

* Updated Redis configuration logic to generate `rediss://` URLs when SSL is enabled, matching redis-py 7.x requirements and removing deprecated `ssl=True` usage. [[1]](diffhunk://#diff-1f6aa9753416b54cc02a01cc97375e445abeb56c8c6dd07aebb681d07d9ffdbaL675-R690) [[2]](diffhunk://#diff-a26d43760f58d93060f0a394e67eba809be57d5e354c6d65f85dbef7479e6deeL71-L82) [[3]](diffhunk://#diff-2077e0ca3c78966d0b3c0b3c0661d6e931a8ad43c5a21f4fc5b77a12bb256088R66)

These changes collectively improve security, configurability, and maintainability of the codebase, especially for Kubernetes-based deployments and environments requiring private container registry access.