### PR TITLE
fix: collect and manage generated files from job executions

### DIFF
--- a/src/services/execution/runner.py
+++ b/src/services/execution/runner.py
@@ -66,7 +66,7 @@ class CodeExecutionRunner:
         self._manager_started = False
         self.active_executions: dict[str, CodeExecution] = {}
         self.session_handles: dict[str, PodHandle] = {}
-        self._job_file_contents: dict[str, bytes] = {}  # path -> content for Job-path files
+        self._job_file_contents: dict[tuple[str, str], bytes] = {}  # (session_id, path) -> content
 
     @property
     def kubernetes_manager(self) -> KubernetesManager:
@@ -206,12 +206,14 @@ class CodeExecutionRunner:
                 # Pool path: detect files via runner HTTP API (pod still alive)
                 generated_files = await self._detect_generated_files(handle)
             elif result.generated_files:
-                # Job path: files were already collected before job cleanup
+                # Job path: files were already collected before job cleanup.
+                # Namespace cached file contents by session to avoid collisions
+                # when different executions produce the same in-pod file path.
                 for f in result.generated_files:
                     path = f.get("path", f"/mnt/data/{f.get('name', '')}")
                     content = f.get("content")
                     if content:
-                        self._job_file_contents[path] = content
+                        self._job_file_contents[(session_id, path)] = content
                 generated_files = [
                     {
                         "path": f.get("path", f"/mnt/data/{f.get('name', '')}"),
@@ -411,13 +413,13 @@ class CodeExecutionRunner:
         """
         return self.session_handles.get(session_id)
 
-    def pop_job_file_content(self, file_path: str) -> bytes | None:
+    def pop_job_file_content(self, session_id: str, file_path: str) -> bytes | None:
         """Pop pre-downloaded file content from a Job execution.
 
         Used by the orchestrator when the pod is already gone (Job path).
         Returns None if the file was not pre-downloaded.
         """
-        return self._job_file_contents.pop(file_path, None)
+        return self._job_file_contents.pop((session_id, file_path), None)
 
     async def get_execution(self, execution_id: str) -> CodeExecution | None:
         """Retrieve an execution by ID."""

--- a/src/services/execution/runner.py
+++ b/src/services/execution/runner.py
@@ -27,6 +27,23 @@ from .output import OutputProcessor
 
 logger = structlog.get_logger(__name__)
 
+# Source filenames written by the runner for each language (must be skipped during file detection).
+# These match the File field in docker/runner/executor.go LangSpec definitions.
+_CODE_FILENAMES = frozenset({
+    "code.py",   # python / py
+    "code.js",   # javascript / js
+    "code.ts",   # typescript / ts
+    "main.go",   # go
+    "code.php",  # php
+    "code.r",    # r
+    "Code.java", # java
+    "code.c",    # c
+    "code.cpp",  # cpp
+    "main.rs",   # rust / rs
+    "code.f90",  # fortran / f90
+    "code.d",    # d / dlang
+})
+
 
 class CodeExecutionRunner:
     """Core code execution runner using Kubernetes pods.
@@ -47,6 +64,7 @@ class CodeExecutionRunner:
         self._manager_started = False
         self.active_executions: dict[str, CodeExecution] = {}
         self.session_handles: dict[str, PodHandle] = {}
+        self._job_file_contents: dict[str, bytes] = {}  # path -> content for Job-path files
 
     @property
     def kubernetes_manager(self) -> KubernetesManager:
@@ -180,15 +198,26 @@ class CodeExecutionRunner:
             # Process outputs
             outputs = self._process_outputs(result.stdout, result.stderr, end_time)
 
-            # For pod-based execution, check for generated files
+            # Check for generated files
             generated_files = []
             if handle:
-                # Only detect files if code likely generates files
-                should_detect_files = files or any(
-                    kw in request.code for kw in ["open(", "savefig", "to_csv", "write(", ".save("]
-                )
-                if should_detect_files:
-                    generated_files = await self._detect_generated_files(handle)
+                # Pool path: detect files via runner HTTP API (pod still alive)
+                generated_files = await self._detect_generated_files(handle)
+            elif result.generated_files:
+                # Job path: files were already collected before job cleanup
+                for f in result.generated_files:
+                    path = f.get("path", f"/mnt/data/{f.get('name', '')}")
+                    content = f.get("content")
+                    if content:
+                        self._job_file_contents[path] = content
+                generated_files = [
+                    {
+                        "path": f.get("path", f"/mnt/data/{f.get('name', '')}"),
+                        "size": f.get("size", 0),
+                        "mime_type": OutputProcessor.guess_mime_type(f.get("name", "")),
+                    }
+                    for f in result.generated_files
+                ]
 
             mounted_filenames = self._get_mounted_filenames(files)
             filtered_files = self._filter_generated_files(generated_files, mounted_filenames)
@@ -347,9 +376,9 @@ class CodeExecutionRunner:
                     files = data.get("files", [])
                     generated_files = []
                     for f in files:
-                        # Skip code files
+                        # Skip code files (source files written by the runner)
                         name = f.get("name", "")
-                        if name.startswith("code.") or name == "Code.java":
+                        if name in _CODE_FILENAMES:
                             continue
                         if f.get("size", 0) > settings.max_file_size_mb * 1024 * 1024:
                             continue
@@ -379,6 +408,14 @@ class CodeExecutionRunner:
         This method is kept for backward compatibility only.
         """
         return self.session_handles.get(session_id)
+
+    def pop_job_file_content(self, file_path: str) -> bytes | None:
+        """Pop pre-downloaded file content from a Job execution.
+
+        Used by the orchestrator when the pod is already gone (Job path).
+        Returns None if the file was not pre-downloaded.
+        """
+        return self._job_file_contents.pop(file_path, None)
 
     async def get_execution(self, execution_id: str) -> CodeExecution | None:
         """Retrieve an execution by ID."""

--- a/src/services/execution/runner.py
+++ b/src/services/execution/runner.py
@@ -29,20 +29,22 @@ logger = structlog.get_logger(__name__)
 
 # Source filenames written by the runner for each language (must be skipped during file detection).
 # These match the File field in docker/runner/executor.go LangSpec definitions.
-_CODE_FILENAMES = frozenset({
-    "code.py",   # python / py
-    "code.js",   # javascript / js
-    "code.ts",   # typescript / ts
-    "main.go",   # go
-    "code.php",  # php
-    "code.r",    # r
-    "Code.java", # java
-    "code.c",    # c
-    "code.cpp",  # cpp
-    "main.rs",   # rust / rs
-    "code.f90",  # fortran / f90
-    "code.d",    # d / dlang
-})
+_CODE_FILENAMES = frozenset(
+    {
+        "code.py",  # python / py
+        "code.js",  # javascript / js
+        "code.ts",  # typescript / ts
+        "main.go",  # go
+        "code.php",  # php
+        "code.r",  # r
+        "Code.java",  # java
+        "code.c",  # c
+        "code.cpp",  # cpp
+        "main.rs",  # rust / rs
+        "code.f90",  # fortran / f90
+        "code.d",  # d / dlang
+    }
+)
 
 
 class CodeExecutionRunner:

--- a/src/services/interfaces.py
+++ b/src/services/interfaces.py
@@ -94,6 +94,14 @@ class ExecutionServiceInterface(ABC):
         """List executions for a session."""
         pass
 
+    def pop_job_file_content(self, file_path: str) -> bytes | None:
+        """Pop pre-downloaded file content from a Job execution.
+
+        Returns None by default. Overridden by implementations that support
+        Job-path file collection.
+        """
+        return None
+
 
 class FileServiceInterface(ABC):
     """Interface for file management service."""

--- a/src/services/interfaces.py
+++ b/src/services/interfaces.py
@@ -94,7 +94,7 @@ class ExecutionServiceInterface(ABC):
         """List executions for a session."""
         pass
 
-    def pop_job_file_content(self, file_path: str) -> bytes | None:
+    def pop_job_file_content(self, session_id: str, file_path: str) -> bytes | None:
         """Pop pre-downloaded file content from a Job execution.
 
         Returns None by default. Overridden by implementations that support

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -423,9 +423,18 @@ class JobExecutor:
 
         # Code filenames that should be skipped (same set as runner.py)
         code_filenames = {
-            "code.py", "code.js", "code.ts", "main.go", "code.php",
-            "code.r", "Code.java", "code.c", "code.cpp", "main.rs",
-            "code.f90", "code.d",
+            "code.py",
+            "code.js",
+            "code.ts",
+            "main.go",
+            "code.php",
+            "code.r",
+            "Code.java",
+            "code.c",
+            "code.cpp",
+            "main.rs",
+            "code.f90",
+            "code.d",
         }
 
         uploaded_names = set()
@@ -455,15 +464,18 @@ class JobExecutor:
                 # Download file content
                 try:
                     dl_response = await client.get(
-                        f"{runner_url}/files/{name}", timeout=30,
+                        f"{runner_url}/files/{name}",
+                        timeout=30,
                     )
                     if dl_response.status_code == 200:
-                        collected.append({
-                            "name": name,
-                            "path": f"/mnt/data/{name}",
-                            "size": size,
-                            "content": dl_response.content,
-                        })
+                        collected.append(
+                            {
+                                "name": name,
+                                "path": f"/mnt/data/{name}",
+                                "size": size,
+                                "content": dl_response.content,
+                            }
+                        )
                 except Exception as e:
                     logger.warning(
                         "Failed to download generated file from job",

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -416,26 +416,11 @@ class JobExecutor:
             List of dicts with keys: name, path, size, content (bytes)
         """
         from ...config import settings
+        from ...services.execution.runner import _CODE_FILENAMES
 
         runner_url = job.runner_url
         if not runner_url:
             return []
-
-        # Code filenames that should be skipped (same set as runner.py)
-        code_filenames = {
-            "code.py",
-            "code.js",
-            "code.ts",
-            "main.go",
-            "code.php",
-            "code.r",
-            "Code.java",
-            "code.c",
-            "code.cpp",
-            "main.rs",
-            "code.f90",
-            "code.d",
-        }
 
         uploaded_names = set()
         if uploaded_files:
@@ -455,7 +440,7 @@ class JobExecutor:
 
             for f in all_files:
                 name = f.get("name", "")
-                if not name or name in code_filenames or name in uploaded_names:
+                if not name or name in _CODE_FILENAMES or name in uploaded_names:
                     continue
                 size = f.get("size", 0)
                 if size <= 0 or size > settings.max_file_size_mb * 1024 * 1024:

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -398,6 +398,93 @@ class JobExecutor:
                     error=str(e),
                 )
 
+    async def _collect_generated_files(
+        self,
+        job: JobHandle,
+        uploaded_files: list[FileData] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Detect and download generated files from a Job pod before cleanup.
+
+        For Job-based execution the pod is destroyed after this method returns,
+        so we must download file contents here.
+
+        Args:
+            job: Job handle with ready pod
+            uploaded_files: Files that were uploaded before execution (to exclude)
+
+        Returns:
+            List of dicts with keys: name, path, size, content (bytes)
+        """
+        from ...config import settings
+
+        runner_url = job.runner_url
+        if not runner_url:
+            return []
+
+        # Code filenames that should be skipped (same set as runner.py)
+        code_filenames = {
+            "code.py", "code.js", "code.ts", "main.go", "code.php",
+            "code.r", "Code.java", "code.c", "code.cpp", "main.rs",
+            "code.f90", "code.d",
+        }
+
+        uploaded_names = set()
+        if uploaded_files:
+            for f in uploaded_files:
+                uploaded_names.add(f.filename)
+
+        try:
+            client = await self._get_http_client()
+
+            # List files in the working directory
+            response = await client.get(f"{runner_url}/files", timeout=10)
+            if response.status_code != 200:
+                return []
+
+            all_files = response.json().get("files", [])
+            collected = []
+
+            for f in all_files:
+                name = f.get("name", "")
+                if not name or name in code_filenames or name in uploaded_names:
+                    continue
+                size = f.get("size", 0)
+                if size <= 0 or size > settings.max_file_size_mb * 1024 * 1024:
+                    continue
+
+                # Download file content
+                try:
+                    dl_response = await client.get(
+                        f"{runner_url}/files/{name}", timeout=30,
+                    )
+                    if dl_response.status_code == 200:
+                        collected.append({
+                            "name": name,
+                            "path": f"/mnt/data/{name}",
+                            "size": size,
+                            "content": dl_response.content,
+                        })
+                except Exception as e:
+                    logger.warning(
+                        "Failed to download generated file from job",
+                        job_name=job.name,
+                        filename=name,
+                        error=str(e),
+                    )
+
+                if len(collected) >= settings.max_output_files:
+                    break
+
+            return collected
+
+        except Exception as e:
+            logger.warning(
+                "Failed to collect generated files from job",
+                job_name=job.name,
+                error=str(e),
+            )
+            return []
+
     async def execute_with_job(
         self,
         spec: PodSpec,
@@ -458,6 +545,10 @@ class JobExecutor:
                 capture_state=capture_state,
             )
 
+            # Detect and download generated files before job cleanup
+            if job.runner_url and result.exit_code == 0:
+                result.generated_files = await self._collect_generated_files(job, files)
+
             logger.info(
                 "Job execution completed",
                 job_name=job.name,
@@ -465,6 +556,7 @@ class JobExecutor:
                 stdout_len=len(result.stdout),
                 stderr_len=len(result.stderr),
                 stderr_preview=result.stderr[:200] if result.stderr else "",
+                generated_files_count=len(result.generated_files) if result.generated_files else 0,
             )
 
             return result

--- a/src/services/kubernetes/models.py
+++ b/src/services/kubernetes/models.py
@@ -78,6 +78,7 @@ class ExecutionResult:
     execution_time_ms: int
     state: str | None = None  # Base64-encoded state
     state_errors: list[str] | None = None
+    generated_files: list[dict[str, Any]] | None = None  # Files generated during execution (for Job path)
 
 
 @dataclass

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -65,7 +65,6 @@ class ExecutionContext:
     stdout: str = ""
     stderr: str = ""
     container: Any | None = None  # Container used for execution (avoids session lookup)
-    job_file_contents: dict[str, bytes] | None = None  # Pre-downloaded file contents from Job execution
     # State persistence fields
     initial_state: str | None = None
     new_state: str | None = None
@@ -528,7 +527,7 @@ class ExecutionOrchestrator:
 
             try:
                 # Get file content from container or pre-downloaded Job cache
-                file_content = await self._get_file_from_container(ctx.container, file_path)
+                file_content = await self._get_file_from_container(ctx.container, file_path, session_id=ctx.session_id)
 
                 # Store the file
                 file_id = await self.file_service.store_execution_output_file(ctx.session_id, filename, file_content)
@@ -546,7 +545,7 @@ class ExecutionOrchestrator:
 
         return generated
 
-    async def _get_file_from_container(self, container: Any, file_path: str) -> bytes:
+    async def _get_file_from_container(self, container: Any, file_path: str, session_id: str | None = None) -> bytes:
         """Get file content from the execution pod via runner HTTP API.
 
         For Job-based execution where the pod is already destroyed, falls back
@@ -555,12 +554,14 @@ class ExecutionOrchestrator:
         Args:
             container: PodHandle object (passed directly, no session lookup needed)
             file_path: Path to file inside pod (e.g., /mnt/data/output.png)
+            session_id: Session identifier for scoping Job file cache lookups
         """
         if not container:
             # Job path: check for pre-downloaded content
-            job_content = self.execution_service.pop_job_file_content(file_path)
-            if job_content:
-                return job_content
+            if session_id:
+                job_content = self.execution_service.pop_job_file_content(session_id, file_path)
+                if job_content is not None:
+                    return job_content
             return f"# Pod not found for file: {file_path}\n".encode()
 
         # Extract filename from path

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -65,6 +65,7 @@ class ExecutionContext:
     stdout: str = ""
     stderr: str = ""
     container: Any | None = None  # Container used for execution (avoids session lookup)
+    job_file_contents: dict[str, bytes] | None = None  # Pre-downloaded file contents from Job execution
     # State persistence fields
     initial_state: str | None = None
     new_state: str | None = None
@@ -526,7 +527,7 @@ class ExecutionOrchestrator:
                 continue
 
             try:
-                # Get file content from container (use ctx.container directly, no session lookup)
+                # Get file content from container or pre-downloaded Job cache
                 file_content = await self._get_file_from_container(ctx.container, file_path)
 
                 # Store the file
@@ -548,11 +549,18 @@ class ExecutionOrchestrator:
     async def _get_file_from_container(self, container: Any, file_path: str) -> bytes:
         """Get file content from the execution pod via runner HTTP API.
 
+        For Job-based execution where the pod is already destroyed, falls back
+        to pre-downloaded file content stored by the runner.
+
         Args:
             container: PodHandle object (passed directly, no session lookup needed)
             file_path: Path to file inside pod (e.g., /mnt/data/output.png)
         """
         if not container:
+            # Job path: check for pre-downloaded content
+            job_content = self.execution_service.pop_job_file_content(file_path)
+            if job_content:
+                return job_content
             return f"# Pod not found for file: {file_path}\n".encode()
 
         # Extract filename from path

--- a/tests/unit/test_execution_runner.py
+++ b/tests/unit/test_execution_runner.py
@@ -544,17 +544,26 @@ class TestPopJobFileContent:
 
     def test_pop_existing_content(self, runner):
         """Test popping pre-downloaded file content."""
-        runner._job_file_contents["/mnt/data/output.png"] = b"PNG data"
+        runner._job_file_contents[("session-123", "/mnt/data/output.png")] = b"PNG data"
 
-        result = runner.pop_job_file_content("/mnt/data/output.png")
+        result = runner.pop_job_file_content("session-123", "/mnt/data/output.png")
 
         assert result == b"PNG data"
-        assert "/mnt/data/output.png" not in runner._job_file_contents
+        assert ("session-123", "/mnt/data/output.png") not in runner._job_file_contents
 
     def test_pop_nonexistent_content(self, runner):
         """Test popping content for non-existent path."""
-        result = runner.pop_job_file_content("/mnt/data/nonexistent.txt")
+        result = runner.pop_job_file_content("session-123", "/mnt/data/nonexistent.txt")
         assert result is None
+
+    def test_pop_wrong_session(self, runner):
+        """Test that files are scoped by session_id."""
+        runner._job_file_contents[("session-A", "/mnt/data/output.png")] = b"PNG data"
+
+        result = runner.pop_job_file_content("session-B", "/mnt/data/output.png")
+
+        assert result is None
+        assert ("session-A", "/mnt/data/output.png") in runner._job_file_contents
 
 
 class TestGetExecution:

--- a/tests/unit/test_execution_runner.py
+++ b/tests/unit/test_execution_runner.py
@@ -73,6 +73,7 @@ class TestRunnerInit:
         assert runner._manager_started is False
         assert runner.active_executions == {}
         assert runner.session_handles == {}
+        assert runner._job_file_contents == {}
 
     def test_init_without_manager(self):
         """Test initialization without manager."""
@@ -460,7 +461,7 @@ class TestDetectGeneratedFiles:
 
     @pytest.mark.asyncio
     async def test_detect_skips_code_files(self, runner):
-        """Test that code files are skipped."""
+        """Test that all language code files are skipped."""
         handle = MagicMock(
             pod_ip="10.0.0.1",
             runner_url="http://10.0.0.1:8080",
@@ -473,6 +474,16 @@ class TestDetectGeneratedFiles:
             "files": [
                 {"name": "code.py", "size": 100},
                 {"name": "Code.java", "size": 200},
+                {"name": "main.go", "size": 150},
+                {"name": "main.rs", "size": 120},
+                {"name": "code.js", "size": 90},
+                {"name": "code.ts", "size": 80},
+                {"name": "code.c", "size": 70},
+                {"name": "code.cpp", "size": 60},
+                {"name": "code.php", "size": 50},
+                {"name": "code.r", "size": 40},
+                {"name": "code.f90", "size": 30},
+                {"name": "code.d", "size": 20},
                 {"name": "output.txt", "size": 50},
             ]
         }
@@ -525,6 +536,24 @@ class TestGetContainerBySession:
     def test_get_nonexistent_handle(self, runner):
         """Test getting nonexistent handle."""
         result = runner.get_container_by_session("nonexistent")
+        assert result is None
+
+
+class TestPopJobFileContent:
+    """Tests for pop_job_file_content method."""
+
+    def test_pop_existing_content(self, runner):
+        """Test popping pre-downloaded file content."""
+        runner._job_file_contents["/mnt/data/output.png"] = b"PNG data"
+
+        result = runner.pop_job_file_content("/mnt/data/output.png")
+
+        assert result == b"PNG data"
+        assert "/mnt/data/output.png" not in runner._job_file_contents
+
+    def test_pop_nonexistent_content(self, runner):
+        """Test popping content for non-existent path."""
+        result = runner.pop_job_file_content("/mnt/data/nonexistent.txt")
         assert result is None
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -45,6 +45,7 @@ def mock_execution_service():
     service = MagicMock()
     service.execute_code = AsyncMock()
     service.get_container_for_session = AsyncMock(return_value=None)
+    service.pop_job_file_content = MagicMock(return_value=None)
     return service
 
 
@@ -947,10 +948,20 @@ class TestGetFileFromContainer:
 
     @pytest.mark.asyncio
     async def test_get_file_no_container(self, orchestrator):
-        """Test getting file when container is None."""
+        """Test getting file when container is None and no job content."""
         result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt")
 
         assert b"Pod not found" in result
+
+    @pytest.mark.asyncio
+    async def test_get_file_no_container_with_job_content(self, orchestrator, mock_execution_service):
+        """Test getting file when container is None but job content exists."""
+        mock_execution_service.pop_job_file_content = MagicMock(return_value=b"job file data")
+
+        result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt")
+
+        assert result == b"job file data"
+        mock_execution_service.pop_job_file_content.assert_called_once_with("/mnt/data/test.txt")
 
     @pytest.mark.asyncio
     async def test_get_file_success(self, orchestrator, mock_execution_service):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -949,7 +949,7 @@ class TestGetFileFromContainer:
     @pytest.mark.asyncio
     async def test_get_file_no_container(self, orchestrator):
         """Test getting file when container is None and no job content."""
-        result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt")
+        result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt", session_id="session-123")
 
         assert b"Pod not found" in result
 
@@ -958,10 +958,10 @@ class TestGetFileFromContainer:
         """Test getting file when container is None but job content exists."""
         mock_execution_service.pop_job_file_content = MagicMock(return_value=b"job file data")
 
-        result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt")
+        result = await orchestrator._get_file_from_container(None, "/mnt/data/test.txt", session_id="session-123")
 
         assert result == b"job file data"
-        mock_execution_service.pop_job_file_content.assert_called_once_with("/mnt/data/test.txt")
+        mock_execution_service.pop_job_file_content.assert_called_once_with("session-123", "/mnt/data/test.txt")
 
     @pytest.mark.asyncio
     async def test_get_file_success(self, orchestrator, mock_execution_service):


### PR DESCRIPTION
## TL;DR
Fix generated files not always being returned to LibreChat after code execution.

Root causes & fixes:

- Keyword heuristic removed — file detection was gated on keywords like `savefig`, `open(`, etc. in the code; now always runs after execution.
Job-path files collected before pod cleanup — cold-path languages (Go, Rust, Java, …) returned `handle=None` so files were never fetched before the pod was destroyed; files are now downloaded eagerly inside `execute_with_job`.
Code file filter expanded — `main.go` and `main.rs` were not excluded from the generated-files list; all 12 language source filenames are now filtered.

---

This pull request enhances the handling of files generated during code execution, especially for Kubernetes Job-based executions where the pod is destroyed after completion. The main improvements ensure that generated files are detected, downloaded, and made available even after the execution pod is gone. The changes also expand and harden the logic for skipping language source files and improve test coverage for these scenarios.

**File handling improvements for Job-based executions:**

* Added logic to detect and download generated files before Job pod cleanup, storing their contents for later retrieval (`src/services/kubernetes/job_executor.py`, `src/services/kubernetes/models.py`, `src/services/execution/runner.py`). [[1]](diffhunk://#diff-12e23e2ca7604991a60267aca818f8c404610cfee276d28e1ebaa7f412bc8a44R401-R487) [[2]](diffhunk://#diff-12e23e2ca7604991a60267aca818f8c404610cfee276d28e1ebaa7f412bc8a44R548-R559) [[3]](diffhunk://#diff-0e68106d4505ca8c5548543bc1813e7c2d3c5789b62abb963b916b29a05b1e15R81) [[4]](diffhunk://#diff-5415630858ab56f0b97cad986dcfedad50336f6586d51f6200ba2c940bc49b4eL183-R220) [[5]](diffhunk://#diff-5415630858ab56f0b97cad986dcfedad50336f6586d51f6200ba2c940bc49b4eR67)
* Implemented a method (`pop_job_file_content`) to retrieve pre-downloaded file content for Job executions, allowing orchestrator services to access files after the pod is destroyed (`src/services/execution/runner.py`, `src/services/interfaces.py`, `src/services/orchestrator.py`). [[1]](diffhunk://#diff-5415630858ab56f0b97cad986dcfedad50336f6586d51f6200ba2c940bc49b4eR412-R419) [[2]](diffhunk://#diff-84bb4c5a03e40a0ed33bf14529493aed5731149151759e3e3c31849a7454cf7cR97-R104) [[3]](diffhunk://#diff-0a6102415f5f8fdb9b501d87155866a0d1ec6830384801a337b138bca8e814e4R68) [[4]](diffhunk://#diff-0a6102415f5f8fdb9b501d87155866a0d1ec6830384801a337b138bca8e814e4R552-R563)
* Updated orchestrator logic to use pre-downloaded file content as a fallback when the execution pod is no longer available (`src/services/orchestrator.py`). [[1]](diffhunk://#diff-0a6102415f5f8fdb9b501d87155866a0d1ec6830384801a337b138bca8e814e4L529-R530) [[2]](diffhunk://#diff-0a6102415f5f8fdb9b501d87155866a0d1ec6830384801a337b138bca8e814e4R552-R563)

**Source file detection and filtering:**

* Centralized and expanded the set of language source filenames to skip during generated file detection, ensuring all relevant code files are excluded (`src/services/execution/runner.py`, `src/services/kubernetes/job_executor.py`). [[1]](diffhunk://#diff-5415630858ab56f0b97cad986dcfedad50336f6586d51f6200ba2c940bc49b4eR30-R46) [[2]](diffhunk://#diff-5415630858ab56f0b97cad986dcfedad50336f6586d51f6200ba2c940bc49b4eL350-R381) [[3]](diffhunk://#diff-12e23e2ca7604991a60267aca818f8c404610cfee276d28e1ebaa7f412bc8a44R401-R487)

**Test enhancements:**

* Expanded unit tests to cover all code file types in file detection and added tests for the new `pop_job_file_content` logic and orchestrator fallback behavior (`tests/unit/test_execution_runner.py`, `tests/unit/test_orchestrator.py`). [[1]](diffhunk://#diff-e73e4fa7bb7f4e0d02a9eb71b3bcb7c27dc8e78a7853c868ccf3b7f60bf3af52L463-R464) [[2]](diffhunk://#diff-e73e4fa7bb7f4e0d02a9eb71b3bcb7c27dc8e78a7853c868ccf3b7f60bf3af52R477-R486) [[3]](diffhunk://#diff-e73e4fa7bb7f4e0d02a9eb71b3bcb7c27dc8e78a7853c868ccf3b7f60bf3af52R542-R559) [[4]](diffhunk://#diff-f9892bc24dc281f5ec4ae031c0f36dda5c795595f69126df8afb39de11e0578aR48) [[5]](diffhunk://#diff-f9892bc24dc281f5ec4ae031c0f36dda5c795595f69126df8afb39de11e0578aL950-R965)

These changes make file handling more robust for both interactive and batch code execution scenarios, ensuring users can reliably access generated outputs regardless of the execution backend.