### PR TITLE
feat: extended Redis TLS and MinIO credential support

### DIFF
--- a/helm-deployments/kubecoderun/templates/deployment.yaml
+++ b/helm-deployments/kubecoderun/templates/deployment.yaml
@@ -96,6 +96,10 @@ spec:
                 name: {{ .Values.minio.existingSecret }}
             {{- end }}
             {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data
@@ -104,6 +108,9 @@ spec:
             - name: secrets-store
               mountPath: /mnt/secrets-store
               readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: data
@@ -116,6 +123,9 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ include "kubecoderun.fullname" . }}-secrets
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -93,6 +93,22 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Extra environment variables for the API container
+# Useful for mapping secret keys to different env var names
+# Example:
+#   env:
+#     - name: MINIO_ACCESS_KEY
+#       valueFrom:
+#         secretKeyRef:
+#           name: my-bucket-creds
+#           key: AWS_ACCESS_KEY_ID
+env: []
+
+# Extra volumes and volume mounts for the API deployment
+# Useful for mounting CA certificates (e.g. Redis TLS, S3/MinIO TLS)
+extraVolumes: []
+extraVolumeMounts: []
+
 # External Dependencies
 redis:
   # Reference an existing Kubernetes Secret containing REDIS_URL

--- a/src/config/minio.py
+++ b/src/config/minio.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -19,8 +19,16 @@ class MinIOConfig(BaseSettings):
     )
 
     endpoint: str = Field(default="localhost:9000", alias="minio_endpoint")
-    access_key: str | None = Field(default=None, alias="minio_access_key")
-    secret_key: str | None = Field(default=None, alias="minio_secret_key")
+    access_key: str | None = Field(
+        default=None,
+        alias="minio_access_key",
+        validation_alias=AliasChoices("minio_access_key", "aws_access_key_id"),
+    )
+    secret_key: str | None = Field(
+        default=None,
+        alias="minio_secret_key",
+        validation_alias=AliasChoices("minio_secret_key", "aws_secret_access_key"),
+    )
     secure: bool = Field(default=False, alias="minio_secure")
     bucket: str = Field(default="kubecoderun-files", alias="minio_bucket")
     region: str = Field(default="us-east-1", alias="minio_region")

--- a/tests/unit/test_minio_config.py
+++ b/tests/unit/test_minio_config.py
@@ -28,11 +28,7 @@ AWS_CREDENTIAL_VARS = [
 
 def get_clean_env():
     """Return environment with MINIO_ and AWS credential vars removed."""
-    return {
-        k: v
-        for k, v in os.environ.items()
-        if not k.startswith("MINIO_") and k not in AWS_CREDENTIAL_VARS
-    }
+    return {k: v for k, v in os.environ.items() if not k.startswith("MINIO_") and k not in AWS_CREDENTIAL_VARS}
 
 
 class TestMinIOConfigValidation:

--- a/tests/unit/test_minio_config.py
+++ b/tests/unit/test_minio_config.py
@@ -19,10 +19,20 @@ MINIO_ENV_VARS = [
     "MINIO_USE_IAM",
 ]
 
+# AWS env vars that are also used as fallbacks for MinIO credentials
+AWS_CREDENTIAL_VARS = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+]
+
 
 def get_clean_env():
-    """Return environment with MINIO_ vars removed."""
-    return {k: v for k, v in os.environ.items() if not k.startswith("MINIO_")}
+    """Return environment with MINIO_ and AWS credential vars removed."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("MINIO_") and k not in AWS_CREDENTIAL_VARS
+    }
 
 
 class TestMinIOConfigValidation:
@@ -365,3 +375,41 @@ class TestMinIOConfigFromEnvironment:
             assert config.use_iam is True
             assert config.access_key is None
             assert config.secret_key is None
+
+    def test_loads_from_aws_env_vars_as_fallback(self):
+        """Test that AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are accepted as fallbacks."""
+        clean_env = get_clean_env()
+        clean_env.update(
+            {
+                "MINIO_ENDPOINT": "s3.example.com:9000",
+                "AWS_ACCESS_KEY_ID": "aws-access-key",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret-key-value",
+                "MINIO_USE_IAM": "false",
+            }
+        )
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            config = MinIOConfig()
+
+            assert config.access_key == "aws-access-key"
+            assert config.secret_key == "aws-secret-key-value"
+
+    def test_minio_vars_take_precedence_over_aws_vars(self):
+        """Test that MINIO_* env vars take precedence over AWS_* env vars."""
+        clean_env = get_clean_env()
+        clean_env.update(
+            {
+                "MINIO_ENDPOINT": "minio.example.com:9000",
+                "MINIO_ACCESS_KEY": "minio-key",
+                "MINIO_SECRET_KEY": "minio-secret-value",
+                "AWS_ACCESS_KEY_ID": "aws-key",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret-value",
+                "MINIO_USE_IAM": "false",
+            }
+        )
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            config = MinIOConfig()
+
+            assert config.access_key == "minio-key"
+            assert config.secret_key == "minio-secret-value"


### PR DESCRIPTION
## Summary

Adds Helm template flexibility and S3-compatible credential support to unblock deployments with self-signed CAs and non-standard secret key names (e.g. RustFS operator).

- Add `extraVolumes` / `extraVolumeMounts` to the deployment template, enabling users to mount additional volumes such as CA certificates for Redis TLS or S3/MinIO TLS verification
- Add `env` support to the deployment template, enabling individual env var injection with `valueFrom` references for mapping secret keys to different env var names
- Accept `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` as fallbacks for MinIO credentials in app config, since these are the standard S3-compatible env var names created by operators like RustFS Manager

Closes #51

## Changes

### Helm (`deployment.yaml`, `values.yaml`)
- `extraVolumeMounts` block in `spec.containers[0].volumeMounts`
- `extraVolumes` block in `spec.volumes`
- `env` block in `spec.containers[0]` (after `envFrom`)
- Default empty-list values for `env`, `extraVolumes`, `extraVolumeMounts`

### App code (`src/config/minio.py`)
- Use Pydantic `AliasChoices` on `access_key` and `secret_key` fields so `MINIO_ACCESS_KEY` is tried first, falling back to `AWS_ACCESS_KEY_ID` (and likewise for the secret key)

### Tests (`tests/unit/test_minio_config.py`)
- `test_loads_from_aws_env_vars_as_fallback` — verifies `AWS_*` env vars work when `MINIO_*` vars are absent
- `test_minio_vars_take_precedence_over_aws_vars` — verifies `MINIO_*` vars win when both are set
- Updated `get_clean_env()` to also strip `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for test isolation

## Test plan

- [x] All 1313 unit tests pass (`just test-unit`)
- [x] Helm template renders correctly with default values
- [x] Helm template renders correctly with `extraVolumes`, `extraVolumeMounts`, and `env` set
- [ ] Deploy with Redis TLS CA cert mounted via `extraVolumes`/`extraVolumeMounts`
- [ ] Deploy with S3 credentials from `AWS_*` env vars (e.g. RustFS operator secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)