### PR TITLE
fix: native custom CA support for Redis and MinIO

### DIFF
--- a/helm-deployments/kubecoderun/templates/_helpers.tpl
+++ b/helm-deployments/kubecoderun/templates/_helpers.tpl
@@ -103,7 +103,9 @@ Returns true if any of the following conditions are met:
 - minio.existingSecret is not set AND minio.useIAM is false (S3 credentials needed)
 */}}
 {{- define "kubecoderun.needsHelmSecret" -}}
-{{- if or (not .Values.api.existingSecret) (not .Values.redis.existingSecret) (and (not .Values.minio.existingSecret) (not .Values.minio.useIAM)) (and (eq .Values.redis.mode "sentinel") .Values.redis.sentinel.password) }}
+{{- $skipRedisUrl := and .Values.redis.host (not .Values.redis.password) -}}
+{{- $needsRedisUrl := and (not .Values.redis.existingSecret) (not $skipRedisUrl) -}}
+{{- if or (not .Values.api.existingSecret) $needsRedisUrl (and (not .Values.minio.existingSecret) (not .Values.minio.useIAM)) (and (eq .Values.redis.mode "sentinel") .Values.redis.sentinel.password) }}
 {{- true }}
 {{- end }}
 {{- end }}

--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -308,6 +308,13 @@ data:
   WAN_NETWORK_NAME: {{ .Values.network.wan.networkName | quote }}
   WAN_DNS_SERVERS: {{ .Values.network.wan.dnsServers | toJson | quote }}
 
+  # Redis Connection
+  {{- if .Values.redis.host }}
+  REDIS_HOST: {{ .Values.redis.host | quote }}
+  {{- end }}
+  REDIS_PORT: {{ .Values.redis.port | default 6379 | quote }}
+  REDIS_DB: {{ .Values.redis.db | default 0 | quote }}
+
   # Redis Advanced Configuration
   REDIS_MAX_CONNECTIONS: {{ .Values.redis.maxConnections | quote }}
   REDIS_SOCKET_TIMEOUT: {{ .Values.redis.socketTimeout | quote }}
@@ -344,6 +351,9 @@ data:
   MINIO_BUCKET: {{ .Values.minio.bucket | quote }}
   {{- end }}
   MINIO_SECURE: {{ .Values.minio.secure | quote }}
+  {{- if .Values.minio.caCerts }}
+  MINIO_CA_CERTS: {{ .Values.minio.caCerts | quote }}
+  {{- end }}
   MINIO_USE_IAM: {{ .Values.minio.useIAM | quote }}
   {{- if .Values.minio.region }}
   AWS_REGION: {{ .Values.minio.region | quote }}

--- a/helm-deployments/kubecoderun/templates/secret.yaml
+++ b/helm-deployments/kubecoderun/templates/secret.yaml
@@ -20,8 +20,11 @@ stringData:
   {{- end }}
   {{- end }}
   {{- if not .Values.redis.existingSecret }}
-  # Redis URL
+  {{- if not (and .Values.redis.host (not .Values.redis.password)) }}
+  # Redis URL (omitted when redis.host is set without redis.password to allow
+  # the app to build the URL from individual env vars + external password)
   REDIS_URL: {{ include "kubecoderun.redisUrl" . | quote }}
+  {{- end }}
   {{- end }}
   {{- if and (eq .Values.redis.mode "sentinel") .Values.redis.sentinel.password }}
   REDIS_SENTINEL_PASSWORD: {{ .Values.redis.sentinel.password | quote }}

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -115,9 +115,10 @@ redis:
   # When set, the url/host/port/password/db fields below are ignored
   # Expected secret key: REDIS_URL (full connection string)
   existingSecret: ""
-  # External Redis URL (required unless existingSecret is set)
-  url: "redis://redis:6379/0"
-  # Or specify individual fields
+  # External Redis URL — set this OR use host/port/password/db fields below.
+  # When empty, the chart builds the URL from host/port/password/db.
+  url: ""
+  # Individual connection fields (used when url is empty)
   host: ""
   port: 6379
   password: ""

--- a/src/config/minio.py
+++ b/src/config/minio.py
@@ -30,6 +30,7 @@ class MinIOConfig(BaseSettings):
         validation_alias=AliasChoices("minio_secret_key", "aws_secret_access_key"),
     )
     secure: bool = Field(default=False, alias="minio_secure")
+    ca_certs: str | None = Field(default=None, alias="minio_ca_certs")
     bucket: str = Field(default="kubecoderun-files", alias="minio_bucket")
     region: str = Field(default="us-east-1", alias="minio_region")
     use_iam: bool = Field(default=False, alias="minio_use_iam")
@@ -55,6 +56,14 @@ class MinIOConfig(BaseSettings):
 
         return self
 
+    def _get_http_client(self):
+        """Create a custom urllib3 PoolManager when a CA cert is configured."""
+        if not self.ca_certs:
+            return None
+        import urllib3
+
+        return urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=self.ca_certs)
+
     def create_client(self) -> "Minio":
         """Create a MinIO client with the appropriate credentials.
 
@@ -64,6 +73,8 @@ class MinIOConfig(BaseSettings):
         import os
 
         from minio import Minio
+
+        http_client = self._get_http_client()
 
         if self.use_iam:
             # Check if running with IRSA (web identity token)
@@ -95,6 +106,7 @@ class MinIOConfig(BaseSettings):
                     ),
                     secure=self.secure,
                     region=self.region,
+                    http_client=http_client,
                 )
             else:
                 # Fall back to IamAwsProvider for EC2 instance profiles
@@ -105,6 +117,7 @@ class MinIOConfig(BaseSettings):
                     credentials=IamAwsProvider(),
                     secure=self.secure,
                     region=self.region,
+                    http_client=http_client,
                 )
         else:
             # Use static credentials
@@ -114,4 +127,5 @@ class MinIOConfig(BaseSettings):
                 secret_key=self.secret_key,
                 secure=self.secure,
                 region=self.region,
+                http_client=http_client,
             )

--- a/src/config/redis.py
+++ b/src/config/redis.py
@@ -1,5 +1,6 @@
 """Redis configuration."""
 
+import ssl as _ssl
 from urllib.parse import urlparse
 
 from pydantic import Field, field_validator
@@ -80,23 +81,48 @@ class RedisConfig(BaseSettings):
         password_part = f":{self.password}@" if self.password else ""
         return f"{scheme}://{password_part}{self.host}:{self.port}/{self.db}"
 
+    def _build_ssl_context(self) -> _ssl.SSLContext:
+        """Build an ``ssl.SSLContext`` from the configured TLS fields.
+
+        When ``ssl_ca_certs`` points to a custom CA file the context loads it
+        explicitly so that self-signed / private-CA certificates are verified
+        correctly.
+        """
+        cert_reqs_map = {
+            "required": _ssl.CERT_REQUIRED,
+            "optional": _ssl.CERT_OPTIONAL,
+            "none": _ssl.CERT_NONE,
+        }
+        cert_reqs = cert_reqs_map.get(self.ssl_cert_reqs, _ssl.CERT_REQUIRED)
+
+        if self.ssl_ca_certs:
+            ctx = _ssl.create_default_context(cafile=self.ssl_ca_certs)
+        else:
+            ctx = _ssl.create_default_context()
+
+        ctx.check_hostname = self.ssl_check_hostname and cert_reqs != _ssl.CERT_NONE
+        ctx.verify_mode = cert_reqs
+
+        if self.ssl_certfile:
+            ctx.load_cert_chain(certfile=self.ssl_certfile, keyfile=self.ssl_keyfile)
+
+        return ctx
+
     def get_ssl_kwargs(self) -> dict:
         """Get SSL kwargs for Redis client creation.
 
+        Builds a proper ``ssl.SSLContext`` and passes it as ``ssl_context`` so
+        that custom CA certificates (self-signed / private CA) are loaded into
+        the context and verified correctly.
+
         Note: In redis-py 7.x the ``ssl=True`` keyword is no longer accepted by
         ``AbstractConnection.__init__()``.  SSL is instead enabled by using the
-        ``rediss://`` URL scheme (see ``get_url()``).  The ssl_* parameters below
-        are still accepted by ``SSLConnection`` which is automatically selected
-        when the ``rediss://`` scheme is used.
+        ``rediss://`` URL scheme (see ``get_url()``).
         """
         if not self.ssl:
             return {}
         return {
-            "ssl_ca_certs": self.ssl_ca_certs,
-            "ssl_certfile": self.ssl_certfile,
-            "ssl_keyfile": self.ssl_keyfile,
-            "ssl_cert_reqs": self.ssl_cert_reqs,
-            "ssl_check_hostname": self.ssl_check_hostname,
+            "ssl_context": self._build_ssl_context(),
         }
 
     @staticmethod

--- a/tests/unit/test_minio_config.py
+++ b/tests/unit/test_minio_config.py
@@ -17,6 +17,7 @@ MINIO_ENV_VARS = [
     "MINIO_BUCKET",
     "MINIO_REGION",
     "MINIO_USE_IAM",
+    "MINIO_CA_CERTS",
 ]
 
 # AWS env vars that are also used as fallbacks for MinIO credentials
@@ -322,6 +323,59 @@ class TestMinIOClientCreation:
                 assert "amazonaws.com" in provider._sts_endpoint
         finally:
             os.unlink(token_file)
+
+    def test_create_client_without_ca_certs(self):
+        """Test client creation without custom CA certs uses default http_client."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = MinIOConfig(
+                minio_endpoint="minio.example.com:9000",
+                minio_access_key="minioadmin",
+                minio_secret_key="minioadmin123",
+                minio_secure=True,
+                minio_use_iam=False,
+            )
+
+            assert config.ca_certs is None
+            assert config._get_http_client() is None
+
+    def test_create_client_with_ca_certs(self):
+        """Test client creation with custom CA certs uses custom urllib3 PoolManager."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".crt") as f:
+            f.write("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+            ca_file = f.name
+
+        try:
+            with patch.dict(os.environ, get_clean_env(), clear=True):
+                config = MinIOConfig(
+                    minio_endpoint="minio.example.com:9000",
+                    minio_access_key="minioadmin",
+                    minio_secret_key="minioadmin123",
+                    minio_secure=True,
+                    minio_ca_certs=ca_file,
+                    minio_use_iam=False,
+                )
+
+                assert config.ca_certs == ca_file
+                http_client = config._get_http_client()
+                assert http_client is not None
+        finally:
+            os.unlink(ca_file)
+
+    def test_ca_certs_from_env(self):
+        """Test that MINIO_CA_CERTS is loaded from environment."""
+        clean_env = get_clean_env()
+        clean_env.update(
+            {
+                "MINIO_ENDPOINT": "minio.example.com:9000",
+                "MINIO_ACCESS_KEY": "minioadmin",
+                "MINIO_SECRET_KEY": "minioadmin123",
+                "MINIO_CA_CERTS": "/etc/ssl/certs/custom-ca.crt",
+            }
+        )
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            config = MinIOConfig()
+            assert config.ca_certs == "/etc/ssl/certs/custom-ca.crt"
 
 
 class TestMinIOConfigFromEnvironment:

--- a/tests/unit/test_redis_config.py
+++ b/tests/unit/test_redis_config.py
@@ -1,0 +1,175 @@
+"""Tests for Redis configuration."""
+
+import os
+import ssl
+from unittest.mock import patch
+
+from src.config.redis import RedisConfig
+
+REDIS_ENV_VARS = [
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_PASSWORD",
+    "REDIS_DB",
+    "REDIS_URL",
+    "REDIS_SSL",
+    "REDIS_SSL_CA_CERTS",
+    "REDIS_SSL_CERTFILE",
+    "REDIS_SSL_KEYFILE",
+    "REDIS_SSL_CERT_REQS",
+    "REDIS_SSL_CHECK_HOSTNAME",
+    "REDIS_MODE",
+    "REDIS_MAX_CONNECTIONS",
+    "REDIS_SOCKET_TIMEOUT",
+    "REDIS_SOCKET_CONNECT_TIMEOUT",
+    "REDIS_KEY_PREFIX",
+    "REDIS_CLUSTER_NODES",
+    "REDIS_SENTINEL_NODES",
+    "REDIS_SENTINEL_MASTER",
+    "REDIS_SENTINEL_PASSWORD",
+    "REDIS_SENTINEL_DB",
+]
+
+
+def get_clean_env():
+    """Return environment with REDIS_ vars removed."""
+    return {k: v for k, v in os.environ.items() if k not in REDIS_ENV_VARS}
+
+
+class TestRedisGetUrl:
+    """Test RedisConfig.get_url() builds URLs from individual fields."""
+
+    def test_get_url_returns_explicit_url(self):
+        """When REDIS_URL is set, get_url() returns it directly."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_url="redis://custom:6380/1")
+            assert config.get_url() == "redis://custom:6380/1"
+
+    def test_get_url_builds_from_fields(self):
+        """When REDIS_URL is not set, get_url() builds from host/port/db."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_host="my-redis", redis_port=6380, redis_db=2)
+            assert config.get_url() == "redis://my-redis:6380/2"
+
+    def test_get_url_builds_with_password(self):
+        """When password is set, get_url() includes it in the URL."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(
+                redis_host="my-redis",
+                redis_port=6379,
+                redis_password="secret",
+                redis_db=0,
+            )
+            assert config.get_url() == "redis://:secret@my-redis:6379/0"
+
+    def test_get_url_uses_rediss_scheme_when_ssl(self):
+        """When SSL is enabled, get_url() uses rediss:// scheme."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_host="my-redis", redis_ssl=True)
+            assert config.get_url().startswith("rediss://")
+
+    def test_get_url_defaults(self):
+        """Default get_url() returns redis://localhost:6379/0."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig()
+            assert config.get_url() == "redis://localhost:6379/0"
+
+    def test_get_url_from_env_vars(self):
+        """get_url() builds from individual REDIS_* env vars."""
+        clean_env = get_clean_env()
+        clean_env.update(
+            {
+                "REDIS_HOST": "env-redis",
+                "REDIS_PORT": "6380",
+                "REDIS_PASSWORD": "env-pass",
+                "REDIS_DB": "3",
+            }
+        )
+        with patch.dict(os.environ, clean_env, clear=True):
+            config = RedisConfig()
+            assert config.get_url() == "redis://:env-pass@env-redis:6380/3"
+
+
+class TestRedisGetSslKwargs:
+    """Test RedisConfig.get_ssl_kwargs() builds SSL context."""
+
+    def test_ssl_disabled_returns_empty(self):
+        """When SSL is disabled, get_ssl_kwargs() returns empty dict."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=False)
+            assert config.get_ssl_kwargs() == {}
+
+    def test_ssl_enabled_returns_ssl_context(self):
+        """When SSL is enabled, get_ssl_kwargs() returns ssl_context."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=True)
+            kwargs = config.get_ssl_kwargs()
+            assert "ssl_context" in kwargs
+            assert isinstance(kwargs["ssl_context"], ssl.SSLContext)
+
+    def test_ssl_context_has_default_verify_mode(self):
+        """Default SSL context uses CERT_REQUIRED."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=True)
+            ctx = config.get_ssl_kwargs()["ssl_context"]
+            assert ctx.verify_mode == ssl.CERT_REQUIRED
+            assert ctx.check_hostname is True
+
+    def test_ssl_context_cert_reqs_none(self):
+        """When cert_reqs is 'none', verification is disabled."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=True, redis_ssl_cert_reqs="none")
+            ctx = config.get_ssl_kwargs()["ssl_context"]
+            assert ctx.verify_mode == ssl.CERT_NONE
+            assert ctx.check_hostname is False
+
+    def test_ssl_context_cert_reqs_optional(self):
+        """When cert_reqs is 'optional', mode is CERT_OPTIONAL."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(
+                redis_ssl=True,
+                redis_ssl_cert_reqs="optional",
+                redis_ssl_check_hostname=False,
+            )
+            ctx = config.get_ssl_kwargs()["ssl_context"]
+            assert ctx.verify_mode == ssl.CERT_OPTIONAL
+
+    def test_ssl_context_check_hostname_disabled(self):
+        """When check_hostname is False, it is disabled in the context."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=True, redis_ssl_check_hostname=False)
+            ctx = config.get_ssl_kwargs()["ssl_context"]
+            assert ctx.check_hostname is False
+
+    def test_ssl_context_with_ca_certs(self):
+        """When ssl_ca_certs is set, the context loads the CA file."""
+        import tempfile
+
+        # Create a temporary self-signed CA cert for testing
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".pem") as f:
+            # Generate a minimal self-signed cert for test purposes
+            f.write("")  # Empty file won't be loaded, we test the path is used
+            ca_file = f.name
+
+        try:
+            with patch.dict(os.environ, get_clean_env(), clear=True):
+                config = RedisConfig(redis_ssl=True, redis_ssl_ca_certs=ca_file)
+                # _build_ssl_context calls create_default_context(cafile=ca_file)
+                # An empty file will raise an error, which confirms it's being used
+                try:
+                    config._build_ssl_context()
+                except ssl.SSLError:
+                    pass  # Expected - empty file is not a valid cert
+        finally:
+            os.unlink(ca_file)
+
+    def test_ssl_kwargs_no_individual_params(self):
+        """SSL kwargs should only contain ssl_context, not individual params."""
+        with patch.dict(os.environ, get_clean_env(), clear=True):
+            config = RedisConfig(redis_ssl=True)
+            kwargs = config.get_ssl_kwargs()
+            assert "ssl_ca_certs" not in kwargs
+            assert "ssl_certfile" not in kwargs
+            assert "ssl_keyfile" not in kwargs
+            assert "ssl_cert_reqs" not in kwargs
+            assert "ssl_check_hostname" not in kwargs


### PR DESCRIPTION
## Summary

Fixes native loading of custom CA certificates for Redis and MinIO/S3 TLS connections, and enables Redis authentication from individual env vars when the password comes from an external secret.

- **MinIO CA certs**: Render `MINIO_CA_CERTS` in configmap and pass it to the MinIO client via a custom `urllib3.PoolManager`, so S3 endpoints with self-signed CAs verify correctly
- **Redis SSL context**: Replace individual `ssl_*` kwargs with a proper `ssl.SSLContext` built from the configured CA/cert/key files, fixing `CERTIFICATE_VERIFY_FAILED` with self-signed Redis CAs
- **Redis individual connection fields**: Render `REDIS_HOST`/`REDIS_PORT`/`REDIS_DB` in the configmap and skip `REDIS_URL` in the secret when `redis.host` is set without `redis.password`, so the app can build the connection URL from individual env vars + an externally-provided password

Closes #53

## Changes

### Helm chart
- **`configmap.yaml`** — Added `MINIO_CA_CERTS` (when `minio.caCerts` is set) and `REDIS_HOST`/`REDIS_PORT`/`REDIS_DB` (when `redis.host` is set)
- **`secret.yaml`** — `REDIS_URL` is now omitted when `redis.host` is set without `redis.password`, allowing the app to build the URL from individual env vars + externally-provided password
- **`_helpers.tpl`** — Updated `needsHelmSecret` to account for when `REDIS_URL` is not needed
- **`values.yaml`** — Changed `redis.url` default from `"redis://redis:6379/0"` to `""` so the `redisUrl` helper falls through to `redis.host` / default branches correctly

### App code
- **`src/config/minio.py`** — Added `ca_certs` field (`MINIO_CA_CERTS` env var) and `_get_http_client()` that creates a `urllib3.PoolManager` with custom CA; passed `http_client` to all `Minio()` constructors
- **`src/config/redis.py`** — Added `_build_ssl_context()` that creates an `ssl.SSLContext` with `cafile=` when custom CA is configured; `get_ssl_kwargs()` now returns `{"ssl_context": ctx}` instead of individual `ssl_*` params

### Tests
- **`tests/unit/test_minio_config.py`** — 3 new tests: CA cert field loading from env, `_get_http_client()` with/without CA
- **`tests/unit/test_redis_config.py`** — 14 new tests: `get_url()` URL building from individual fields, `get_ssl_kwargs()` SSL context construction (verify modes, hostname checking, CA cert loading)

## Test plan

- [x] All 1330 unit tests pass (`just test-unit`)
- [x] Linter passes (`just lint`)
- [x] Helm template renders `MINIO_CA_CERTS` when `minio.caCerts` is set
- [x] Helm template renders `REDIS_HOST`/`REDIS_PORT`/`REDIS_DB` when `redis.host` is set
- [x] Helm template omits `REDIS_URL` when `redis.host` is set without `redis.password`
- [x] Helm template includes `REDIS_URL` when `redis.host` + `redis.password` are both set
- [x] Helm template backward-compatible (default renders `REDIS_URL: redis://redis:6379/0`)
- [ ] Deploy with Redis TLS using custom CA cert
- [ ] Deploy with MinIO/S3 using custom CA cert
- [ ] Deploy with Redis password from external secret via `env` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)