### PR TITLE
feature/rehydrate session files

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,6 +185,21 @@ COPY --from=runner /runner /usr/local/bin/runner
 7. Client Response
 ```
 
+## File Persistence Across Executions
+
+Pool pods are destroyed after every execution and their `/mnt/data`
+volume is an ephemeral `emptyDir`. To keep uploaded files available
+across multiple `POST /exec` calls on the same session, the orchestrator
+re-hydrates every uploaded file associated with the execution session
+from MinIO on each request — in addition to whatever the client lists
+in `request.files`. Generated outputs (stored under `/outputs/…`) are
+skipped to avoid collisions with files produced by earlier runs.
+
+The number of files re-hydrated this way is returned to the client in
+the `auto_mounted_files` field of `ExecResponse`, making pod rotations
+(pool churn, OOMKills, evictions) observable without changing the
+LibreChat-compatible response shape.
+
 ## State Persistence (Python)
 
 Python sessions support state persistence across executions:

--- a/src/models/exec.py
+++ b/src/models/exec.py
@@ -61,3 +61,11 @@ class ExecResponse(BaseModel):
     )
     state_size: int | None = Field(default=None, description="Compressed state size in bytes")
     state_hash: str | None = Field(default=None, description="SHA256 hash for ETag/change detection")
+    auto_mounted_files: int = Field(
+        default=0,
+        description=(
+            "Number of session-scoped uploaded files that were automatically "
+            "re-hydrated from storage into /mnt/data because the pod was fresh. "
+            "Surfaces pod rotations caused by pool churn, OOMKills or evictions."
+        ),
+    )

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -535,20 +535,56 @@ class PodPool:
         client = await self._get_http_client()
         runner_url = handle.runner_url
 
-        # Upload files if provided
+        # Upload files if provided. Large files (observed in issue #57 for
+        # datasets >16 MB) can exceed a fixed 30s window; scale the timeout
+        # with payload size and fail fast with a clear error so callers know
+        # the execution environment is missing expected files.
         if files:
             for file_data in files:
+                upload_timeout = max(30, len(file_data.content) // (1024 * 1024) + 30)
                 try:
-                    await client.post(
+                    response = await client.post(
                         f"{runner_url}/files",
                         files={"files": (file_data.filename, file_data.content)},
-                        timeout=30,
+                        timeout=upload_timeout,
+                    )
+                    if response.status_code >= 400:
+                        return ExecutionResult(
+                            exit_code=1,
+                            stdout="",
+                            stderr=(
+                                f"Failed to upload '{file_data.filename}' to execution pod "
+                                f"(runner returned {response.status_code}). The pod may have "
+                                "been restarted mid-request."
+                            ),
+                            execution_time_ms=0,
+                        )
+                except httpx.TimeoutException:
+                    return ExecutionResult(
+                        exit_code=1,
+                        stdout="",
+                        stderr=(
+                            f"Timed out uploading '{file_data.filename}' ({len(file_data.content)} bytes) "
+                            f"to execution pod after {upload_timeout}s. Consider reducing file size "
+                            "or raising max_file_size_mb."
+                        ),
+                        execution_time_ms=0,
                     )
                 except Exception as e:
-                    logger.warning(
-                        "Failed to upload file",
+                    logger.error(
+                        "Failed to upload file to pod",
+                        pod_name=handle.name,
                         filename=file_data.filename,
                         error=str(e),
+                    )
+                    return ExecutionResult(
+                        exit_code=1,
+                        stdout="",
+                        stderr=(
+                            f"Failed to upload '{file_data.filename}' to execution pod: {e}. "
+                            "The pod may have been restarted (OOM or timeout)."
+                        ),
+                        execution_time_ms=0,
                     )
 
         # Execute code
@@ -600,12 +636,58 @@ class PodPool:
                 pod_name=handle.name,
                 error=str(e),
             )
+            # Inspect the pod so the caller learns *why* the connection dropped
+            # (issue #57: "socket hang up" typically means the pod was
+            # OOMKilled or evicted mid-request).
+            pod_failure_reason = await self._inspect_pod_failure(handle)
+            stderr = f"Execution error: {str(e)}"
+            if pod_failure_reason:
+                stderr = f"{stderr}. Pod status: {pod_failure_reason}"
             return ExecutionResult(
                 exit_code=1,
                 stdout="",
-                stderr=f"Execution error: {str(e)}",
+                stderr=stderr,
                 execution_time_ms=0,
             )
+
+    async def _inspect_pod_failure(self, handle: PodHandle) -> str | None:
+        """Best-effort lookup of why a pod stopped responding.
+
+        Returns a short human-readable reason (e.g. "OOMKilled", "Evicted")
+        or None if the pod still appears healthy or the K8s API is
+        unavailable. Used to turn opaque "socket hang up" errors into
+        actionable messages.
+        """
+        core_api = get_core_api()
+        if not core_api:
+            return None
+
+        try:
+            loop = asyncio.get_event_loop()
+            pod = await loop.run_in_executor(
+                None,
+                lambda: core_api.read_namespaced_pod(handle.name, handle.namespace),
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return "pod not found (deleted or restarted)"
+            return None
+        except Exception:
+            return None
+
+        phase = getattr(pod.status, "phase", None)
+        reason = getattr(pod.status, "reason", None)
+        if reason:
+            return reason
+        if pod.status and pod.status.container_statuses:
+            for cs in pod.status.container_statuses:
+                terminated = getattr(getattr(cs, "last_state", None), "terminated", None)
+                if terminated and terminated.reason:
+                    return terminated.reason
+                waiting = getattr(getattr(cs, "state", None), "waiting", None)
+                if waiting and waiting.reason:
+                    return waiting.reason
+        return phase
 
     @property
     def available_count(self) -> int:

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -291,12 +291,19 @@ class ExecutionOrchestrator:
         return session.session_id
 
     async def _mount_files(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
-        """Mount files for code execution."""
-        if not ctx.request.files:
-            return []
+        """Mount files for code execution.
 
-        mounted = []
-        mounted_ids = set()
+        Pool pods are destroyed after every execution and their /mnt/data
+        volume is an ephemeral emptyDir, so files uploaded in a previous
+        request do not persist in the pod. To keep the user-visible
+        "/mnt/data" illusion stable across requests (issue #57), every
+        uploaded file associated with the execution session is re-hydrated
+        from MinIO on each call, in addition to whatever the client
+        explicitly referenced in request.files.
+        """
+        mounted: list[dict[str, Any]] = []
+        mounted_keys: set[tuple[str, str]] = set()
+        mounted_filenames: set[str] = set()
 
         for file_ref in ctx.request.files:
             # Get file info - try by ID first
@@ -319,9 +326,9 @@ class ExecutionOrchestrator:
                 )
                 continue
 
-            # Skip duplicates
+            # Skip duplicates (by id and by filename)
             key = (file_ref.session_id, file_info.file_id)
-            if key in mounted_ids:
+            if key in mounted_keys or file_info.filename in mounted_filenames:
                 continue
 
             # Fetch actual file content from MinIO storage
@@ -344,9 +351,11 @@ class ExecutionOrchestrator:
                     "size": file_info.size,
                     "session_id": file_ref.session_id,
                     "content": content,
+                    "auto_mounted": False,
                 }
             )
-            mounted_ids.add(key)
+            mounted_keys.add(key)
+            mounted_filenames.add(file_info.filename)
 
             # Consolidate cross-session files into the chosen session (issue #34).
             # When files are uploaded in separate sessions (e.g. entity_id=null),
@@ -380,6 +389,71 @@ class ExecutionOrchestrator:
                 file_id=file_info.file_id,
                 filename=file_info.filename,
                 size=len(content),
+            )
+
+        # Re-hydrate uploaded files that belong to the execution session but
+        # were not explicitly referenced in the request. Skips generated
+        # outputs (path starts with "/outputs/") to avoid collisions with
+        # files produced by previous executions.
+        auto_mount_count = 0
+        if ctx.session_id:
+            try:
+                session_files = await self.file_service.list_files(ctx.session_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to list session files for auto-mount",
+                    session_id=ctx.session_id[:12],
+                    error=str(e),
+                )
+                session_files = []
+
+            for file_info in session_files:
+                if file_info.path and file_info.path.startswith("/outputs/"):
+                    continue
+
+                key = (ctx.session_id, file_info.file_id)
+                if key in mounted_keys or file_info.filename in mounted_filenames:
+                    continue
+
+                content = await self.file_service.get_file_content(ctx.session_id, file_info.file_id)
+                if content is None:
+                    logger.warning(
+                        "Failed to fetch session file content for auto-mount",
+                        session_id=ctx.session_id[:12],
+                        file_id=file_info.file_id,
+                        filename=file_info.filename,
+                    )
+                    continue
+
+                mounted.append(
+                    {
+                        "file_id": file_info.file_id,
+                        "filename": file_info.filename,
+                        "path": file_info.path,
+                        "size": file_info.size,
+                        "session_id": ctx.session_id,
+                        "content": content,
+                        "auto_mounted": True,
+                    }
+                )
+                mounted_keys.add(key)
+                mounted_filenames.add(file_info.filename)
+                auto_mount_count += 1
+
+                logger.debug(
+                    "Auto-mounted session file",
+                    session_id=ctx.session_id[:12],
+                    file_id=file_info.file_id,
+                    filename=file_info.filename,
+                    size=len(content),
+                )
+
+        if auto_mount_count:
+            logger.info(
+                "Re-hydrated session files from MinIO",
+                session_id=ctx.session_id[:12] if ctx.session_id else None,
+                auto_mounted=auto_mount_count,
+                explicit=len(mounted) - auto_mount_count,
             )
 
         return mounted
@@ -618,6 +692,8 @@ class ExecutionOrchestrator:
                 # Fallback to base64 string length if decode fails
                 state_size = len(ctx.new_state)
 
+        auto_mounted = sum(1 for f in ctx.mounted_files if f.get("auto_mounted")) if ctx.mounted_files else 0
+
         return ExecResponse(
             session_id=ctx.session_id,
             files=ctx.generated_files or [],
@@ -626,6 +702,7 @@ class ExecutionOrchestrator:
             has_state=has_state,
             state_size=state_size,
             state_hash=state_hash,
+            auto_mounted_files=auto_mounted,
         )
 
     async def _cleanup(self, ctx: ExecutionContext) -> None:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -576,6 +576,99 @@ class TestMountFilesExtended:
         # Should only include one file
         assert len(result) == 1
 
+    @pytest.mark.asyncio
+    async def test_mount_files_auto_mount_session_files(self, orchestrator, mock_file_service):
+        """Session-scoped files should be re-hydrated from MinIO even when
+        request.files is empty (issue #57: pool pods are destroyed after
+        each execution, emptyDir /mnt/data is ephemeral)."""
+        from datetime import datetime
+
+        from src.models.files import FileInfo
+
+        session_file = FileInfo(
+            file_id="file-upload-1",
+            filename="data.csv",
+            size=2048,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/data.csv",
+        )
+        mock_file_service.list_files.return_value = [session_file]
+        mock_file_service.get_file_content.return_value = b"a,b\n1,2\n"
+
+        request = ExecRequest(code="print('hi')", lang="python", files=[])
+        ctx = ExecutionContext(request=request, request_id="req-1", session_id="session-abc")
+
+        result = await orchestrator._mount_files(ctx)
+
+        assert len(result) == 1
+        assert result[0]["filename"] == "data.csv"
+        assert result[0]["auto_mounted"] is True
+        assert result[0]["content"] == b"a,b\n1,2\n"
+
+    @pytest.mark.asyncio
+    async def test_mount_files_auto_mount_skips_outputs(self, orchestrator, mock_file_service):
+        """Generated output files (path starts with /outputs/) must not be
+        auto-mounted — only uploads re-hydrate into /mnt/data."""
+        from datetime import datetime
+
+        from src.models.files import FileInfo
+
+        upload = FileInfo(
+            file_id="file-upload-1",
+            filename="data.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/data.csv",
+        )
+        output = FileInfo(
+            file_id="file-output-1",
+            filename="chart.png",
+            size=10,
+            content_type="image/png",
+            created_at=datetime.now(),
+            path="/outputs/chart.png",
+        )
+        mock_file_service.list_files.return_value = [upload, output]
+
+        request = ExecRequest(code="print('hi')", lang="python", files=[])
+        ctx = ExecutionContext(request=request, request_id="req-1", session_id="session-abc")
+
+        result = await orchestrator._mount_files(ctx)
+
+        assert len(result) == 1
+        assert result[0]["filename"] == "data.csv"
+
+    @pytest.mark.asyncio
+    async def test_mount_files_auto_mount_dedupes_with_explicit(self, orchestrator, mock_file_service):
+        """When a file is explicitly in request.files, the auto-mount pass
+        must not mount it again (dedup by filename and by (session,file_id))."""
+        from datetime import datetime
+
+        from src.models.exec import RequestFile
+        from src.models.files import FileInfo
+
+        file_info = FileInfo(
+            file_id="file-123",
+            filename="data.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/data.csv",
+        )
+        mock_file_service.get_file_info.return_value = file_info
+        mock_file_service.list_files.return_value = [file_info]
+
+        request_file = RequestFile(id="file-123", session_id="session-abc", name="data.csv")
+        request = ExecRequest(code="print('hi')", lang="python", files=[request_file])
+        ctx = ExecutionContext(request=request, request_id="req-1", session_id="session-abc")
+
+        result = await orchestrator._mount_files(ctx)
+
+        assert len(result) == 1
+        assert result[0]["auto_mounted"] is False
+
 
 class TestLoadState:
     """Tests for _load_state method."""

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -993,25 +993,14 @@ class TestPodPoolExecuteExtended:
 
     @pytest.mark.asyncio
     async def test_execute_with_file_upload_failure(self, pod_pool, pod_handle):
-        """Test execution with file upload failure."""
+        """Upload failures must surface to the caller (issue #57) instead of
+        silently continuing with a pod missing expected inputs."""
         mock_client = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "exit_code": 0,
-            "stdout": "OK",
-            "stderr": "",
-            "execution_time_ms": 50,
-        }
-
-        call_count = 0
 
         async def mock_post(url, **kwargs):
-            nonlocal call_count
-            call_count += 1
             if "/files" in url:
                 raise Exception("Upload failed")
-            return mock_response
+            return MagicMock(status_code=200, json=MagicMock(return_value={}))
 
         mock_client.post = mock_post
 
@@ -1020,8 +1009,102 @@ class TestPodPoolExecuteExtended:
         with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
             result = await pod_pool.execute(pod_handle, "print('test')", files=files)
 
-        # Should still try to execute even if file upload fails
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert "test.py" in result.stderr
+        assert "upload" in result.stderr.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_with_file_upload_timeout(self, pod_pool, pod_handle):
+        """Large file uploads that exceed the per-file timeout must fail with
+        an actionable error mentioning the file name (issue #57 root cause
+        for >16 MB datasets)."""
+        import httpx
+
+        mock_client = AsyncMock()
+
+        async def mock_post(url, **kwargs):
+            if "/files" in url:
+                raise httpx.TimeoutException("socket hang up")
+            return MagicMock(status_code=200, json=MagicMock(return_value={}))
+
+        mock_client.post = mock_post
+
+        files = [FileData(filename="big.csv", content=b"x" * (2 * 1024 * 1024))]
+
+        with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
+            result = await pod_pool.execute(pod_handle, "print('hi')", files=files)
+
+        assert result.exit_code == 1
+        assert "big.csv" in result.stderr
+        assert "Timed out" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_execute_with_file_upload_runner_4xx(self, pod_pool, pod_handle):
+        """A 4xx from the runner during file upload must abort the execution
+        with a clear error, not proceed to /execute."""
+        mock_client = AsyncMock()
+
+        async def mock_post(url, **kwargs):
+            if "/files" in url:
+                return MagicMock(status_code=413)
+            return MagicMock(status_code=200, json=MagicMock(return_value={}))
+
+        mock_client.post = mock_post
+
+        files = [FileData(filename="payload.bin", content=b"x" * 100)]
+
+        with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
+            result = await pod_pool.execute(pod_handle, "print('hi')", files=files)
+
+        assert result.exit_code == 1
+        assert "413" in result.stderr
+        assert "payload.bin" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_execute_generic_exception_appends_pod_failure(self, pod_pool, pod_handle):
+        """When the /execute request fails, the stderr should include the
+        pod's terminal reason (e.g. OOMKilled) so users know the pod died."""
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("socket hang up"))
+
+        with patch.object(pod_pool, "_get_http_client", return_value=mock_client):
+            with patch.object(pod_pool, "_inspect_pod_failure", AsyncMock(return_value="OOMKilled")):
+                result = await pod_pool.execute(pod_handle, "x = [0]*10**9")
+
+        assert result.exit_code == 1
+        assert "OOMKilled" in result.stderr
+        assert "socket hang up" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_inspect_pod_failure_returns_terminated_reason(self, pod_pool, pod_handle):
+        """_inspect_pod_failure should surface container terminated reasons."""
+        fake_terminated = MagicMock(reason="OOMKilled")
+        fake_last_state = MagicMock(terminated=fake_terminated)
+        fake_cs = MagicMock(last_state=fake_last_state, state=MagicMock(waiting=None))
+        fake_pod = MagicMock()
+        fake_pod.status.phase = "Running"
+        fake_pod.status.reason = None
+        fake_pod.status.container_statuses = [fake_cs]
+
+        fake_api = MagicMock()
+        fake_api.read_namespaced_pod = MagicMock(return_value=fake_pod)
+
+        with patch("src.services.kubernetes.pool.get_core_api", return_value=fake_api):
+            reason = await pod_pool._inspect_pod_failure(pod_handle)
+
+        assert reason == "OOMKilled"
+
+    @pytest.mark.asyncio
+    async def test_inspect_pod_failure_handles_missing_pod(self, pod_pool, pod_handle):
+        """A 404 from the Kubernetes API must translate into a helpful string."""
+        fake_api = MagicMock()
+        fake_api.read_namespaced_pod = MagicMock(side_effect=ApiException(status=404))
+
+        with patch("src.services.kubernetes.pool.get_core_api", return_value=fake_api):
+            reason = await pod_pool._inspect_pod_failure(pod_handle)
+
+        assert reason is not None
+        assert "not found" in reason
 
     @pytest.mark.asyncio
     async def test_execute_with_initial_state(self, pod_pool, pod_handle):


### PR DESCRIPTION
## Summary

Fixes #57

This PR addresses critical issues with file uploads and execution reliability:

1. **File upload failures now surface to callers** instead of silently continuing with missing inputs. The executor now validates upload responses and returns actionable error messages for timeouts, 4xx errors, and exceptions.

2. **Dynamic timeout scaling for large files** — upload timeouts now scale with payload size (30s base + 1s per MB) to handle datasets >16 MB that were timing out with a fixed 30s window.

3. **Pod failure diagnostics** — when execution fails with opaque errors like "socket hang up", the system now inspects the pod's Kubernetes status to surface the actual reason (OOMKilled, Evicted, etc.), helping users understand why their code didn't run.

4. **File persistence across executions** — pool pods are destroyed after each execution with ephemeral `/mnt/data` volumes. The orchestrator now automatically re-hydrates all uploaded files from MinIO on each request, maintaining the illusion of persistent storage across multiple `POST /exec` calls on the same session. Generated outputs (under `/outputs/`) are excluded to avoid collisions.

5. **Observability** — the `ExecResponse` now includes `auto_mounted_files` count, making pod rotations (pool churn, OOMKills, evictions) observable to clients.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added 7 new unit tests covering:
  - File upload failures with proper error messages
  - Timeout handling for large files with actionable feedback
  - 4xx HTTP responses from runner during upload
  - Generic execution exceptions with pod failure inspection
  - Pod failure reason extraction from Kubernetes API
  - Missing pod (404) handling
  - Session file auto-mounting and deduplication
  - Output file exclusion from auto-mount
  - Deduplication between explicit and auto-mounted files

- Updated existing test `test_execute_with_file_upload_failure` to verify failures are surfaced (exit_code=1) rather than silently continuing

- All tests pass with the new implementation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (ARCHITECTURE.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01MDKbmtnXZTGqC6zZAYhns4