### PR TITLE
fix: add JSON body API key extraction for @librechat/agents ≥3.1.74 compatibility

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -192,6 +192,7 @@ build_image() {
 
     # shellcheck disable=SC2086
     build_output=$(docker build \
+        --platform linux/amd64 \
         $NO_CACHE \
         --build-arg VERSION="$TAG" \
         --build-arg BUILD_DATE="$build_date" \
@@ -284,6 +285,7 @@ build_single_image() {
             vcs_ref=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
             # shellcheck disable=SC2086
             docker build \
+                --platform linux/amd64 \
                 $NO_CACHE \
                 --build-arg VERSION="$TAG" \
                 --build-arg BUILD_DATE="$build_date" \

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
         description="Master API key for admin operations (CLI key management)",
     )
     rate_limit_enabled: bool = Field(default=True, description="Enable per-key rate limiting for Redis-managed keys")
+    auth_trusted_networks: str = Field(
+        default="",
+        description="Comma-separated CIDRs that bypass API key auth (e.g. '10.0.0.0/8,172.16.0.0/12')",
+    )
 
     # Redis Configuration
     redis_host: str = Field(default="localhost")

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,5 +1,6 @@
 """Authentication middleware for API key validation."""
 
+import json
 import time
 from typing import Callable, Optional
 
@@ -40,7 +41,15 @@ class AuthenticationMiddleware:
             return
 
         try:
-            await self._authenticate_request(request, scope)
+            # Try header-based extraction first
+            api_key = self._extract_api_key(request)
+
+            # If no key in headers, try JSON body extraction for POST/PUT/PATCH
+            if api_key is None and request.method in ("POST", "PUT", "PATCH"):
+                body_bytes, receive = await self._buffer_body(receive)
+                api_key = self._extract_api_key_from_body(body_bytes)
+
+            await self._authenticate_request(request, scope, api_key=api_key)
         except HTTPException as e:
             response = JSONResponse(
                 status_code=e.status_code,
@@ -66,10 +75,11 @@ class AuthenticationMiddleware:
         """Check if authentication should be skipped."""
         return request.url.path in self.excluded_paths or request.method == "OPTIONS"
 
-    async def _authenticate_request(self, request: Request, scope: dict):
+    async def _authenticate_request(self, request: Request, scope: dict, *, api_key: str | None = None):
         """Handle API key authentication."""
-        # Extract API key
-        api_key = self._extract_api_key(request)
+        # Use provided api_key or extract from headers as fallback
+        if api_key is None:
+            api_key = self._extract_api_key(request)
 
         # Get authentication service
         auth_service = await get_auth_service()
@@ -107,6 +117,55 @@ class AuthenticationMiddleware:
                 return auth_header[7:]
 
         return None
+
+    def _extract_api_key_from_body(self, body: bytes) -> str | None:
+        """Extract API key from JSON request body fields.
+
+        Supports @librechat/agents >=3.1.74 which spreads params into the
+        request body instead of sending the key as a header.
+        """
+        if not body:
+            return None
+        try:
+            data = json.loads(body)
+            if not isinstance(data, dict):
+                return None
+            for field in ("LIBRECHAT_CODE_API_KEY", "api_key", "apiKey"):
+                if key := data.get(field):
+                    if isinstance(key, str) and key.strip():
+                        return key.strip()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+        return None
+
+    async def _buffer_body(self, receive: Callable) -> tuple[bytes, Callable]:
+        """Read and buffer the request body, returning a replay receive callable.
+
+        This ensures the body remains available for downstream handlers after
+        the middleware has inspected it.
+        """
+        body_parts: list[bytes] = []
+        while True:
+            message = await receive()
+            body = message.get("body", b"")
+            if body:
+                body_parts.append(body)
+            if not message.get("more_body", False):
+                break
+
+        full_body = b"".join(body_parts)
+
+        # Create a replay receive that returns the buffered body
+        body_sent = False
+
+        async def replay_receive() -> dict:
+            nonlocal body_sent
+            if not body_sent:
+                body_sent = True
+                return {"type": "http.request", "body": full_body, "more_body": False}
+            return {"type": "http.disconnect"}
+
+        return full_body, replay_receive
 
     def _get_client_ip(self, request: Request) -> str:
         """Get client IP address."""

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -107,10 +107,14 @@ class AuthenticationMiddleware:
         return networks
 
     def _is_trusted_network(self, request: Request) -> bool:
-        """Check if the client IP falls within a trusted CIDR range."""
-        client_ip_str = self._get_client_ip(request)
-        if client_ip_str == "unknown":
+        """Check if the client IP falls within a trusted CIDR range.
+
+        Uses the actual socket peer address (request.client.host) rather than
+        forwarded headers to prevent IP spoofing attacks.
+        """
+        if not request.client:
             return False
+        client_ip_str = request.client.host
         try:
             client_ip = ipaddress.ip_address(client_ip_str)
         except ValueError:
@@ -122,6 +126,9 @@ class AuthenticationMiddleware:
         # Use provided api_key or extract from headers as fallback
         if api_key is None:
             api_key = self._extract_api_key(request)
+
+        if not api_key:
+            raise HTTPException(status_code=401, detail="Missing API key")
 
         # Get authentication service
         auth_service = await get_auth_service()

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,5 +1,6 @@
 """Authentication middleware for API key validation."""
 
+import ipaddress
 import json
 import time
 from typing import Callable, Optional
@@ -8,6 +9,7 @@ import structlog
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from ..config import settings
 from ..services.auth import get_auth_service
 
 logger = structlog.get_logger(__name__)
@@ -30,6 +32,7 @@ class AuthenticationMiddleware:
     def __init__(self, app: Callable):
         self.app = app
         self.excluded_paths = {"/health", "/docs", "/redoc", "/openapi.json"}
+        self._trusted_networks = self._parse_trusted_networks(settings.auth_trusted_networks)
 
     async def __call__(self, scope: dict, receive: Callable, send: Callable):
         """Process request through authentication middleware."""
@@ -78,7 +81,41 @@ class AuthenticationMiddleware:
 
     def _should_skip_auth(self, request: Request) -> bool:
         """Check if authentication should be skipped."""
-        return request.url.path in self.excluded_paths or request.method == "OPTIONS"
+        if request.url.path in self.excluded_paths or request.method == "OPTIONS":
+            return True
+
+        # Bypass auth for requests from trusted networks (e.g. in-cluster callers)
+        if self._trusted_networks and self._is_trusted_network(request):
+            return True
+
+        return False
+
+    @staticmethod
+    def _parse_trusted_networks(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+        """Parse comma-separated CIDR strings into network objects."""
+        networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        if not raw:
+            return networks
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            try:
+                networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                logger.warning("Invalid trusted network CIDR, skipping", cidr=entry)
+        return networks
+
+    def _is_trusted_network(self, request: Request) -> bool:
+        """Check if the client IP falls within a trusted CIDR range."""
+        client_ip_str = self._get_client_ip(request)
+        if client_ip_str == "unknown":
+            return False
+        try:
+            client_ip = ipaddress.ip_address(client_ip_str)
+        except ValueError:
+            return False
+        return any(client_ip in network for network in self._trusted_networks)
 
     async def _authenticate_request(self, request: Request, scope: dict, *, api_key: str | None = None):
         """Handle API key authentication."""

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -12,6 +12,10 @@ from ..services.auth import get_auth_service
 
 logger = structlog.get_logger(__name__)
 
+# Max bytes to buffer when inspecting the request body for an API key.
+# Keeps memory bounded for unauthenticated requests (issue #59 review).
+_MAX_AUTH_BODY_BYTES = 1 * 1024 * 1024  # 1 MB
+
 
 class AuthenticationMiddleware:
     """Middleware for API key authentication.
@@ -45,7 +49,8 @@ class AuthenticationMiddleware:
             api_key = self._extract_api_key(request)
 
             # If no key in headers, try JSON body extraction for POST/PUT/PATCH
-            if api_key is None and request.method in ("POST", "PUT", "PATCH"):
+            content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+            if api_key is None and request.method in ("POST", "PUT", "PATCH") and content_type == "application/json":
                 body_bytes, receive = await self._buffer_body(receive)
                 api_key = self._extract_api_key_from_body(body_bytes)
 
@@ -145,10 +150,14 @@ class AuthenticationMiddleware:
         the middleware has inspected it.
         """
         body_parts: list[bytes] = []
+        total = 0
         while True:
             message = await receive()
             body = message.get("body", b"")
             if body:
+                total += len(body)
+                if total > _MAX_AUTH_BODY_BYTES:
+                    raise HTTPException(status_code=413, detail="Request body too large")
                 body_parts.append(body)
             if not message.get("more_body", False):
                 break

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -1,6 +1,7 @@
 """Consolidated security middleware for the Code Interpreter API."""
 
 # Standard library imports
+import ipaddress
 import json
 import time
 from typing import Callable, Optional
@@ -36,6 +37,7 @@ class SecurityMiddleware:
             "/api/v1/admin",
             "/admin-dashboard",
         }
+        self._trusted_networks = self._parse_trusted_networks(settings.auth_trusted_networks)
 
     async def __call__(self, scope: dict, receive: Callable, send: Callable):
         """Process request through consolidated security middleware."""
@@ -157,12 +159,46 @@ class SecurityMiddleware:
     def _should_skip_auth(self, request: Request) -> bool:
         """Check if authentication should be skipped."""
         path = request.url.path
-        return (
+        if (
             path in self.excluded_paths
             or path.startswith("/api/v1/admin")
             or path.startswith("/admin-dashboard")
             or request.method == "OPTIONS"
-        )
+        ):
+            return True
+
+        # Bypass auth for requests from trusted networks (e.g. in-cluster callers)
+        if self._trusted_networks and self._is_trusted_network(request):
+            return True
+
+        return False
+
+    @staticmethod
+    def _parse_trusted_networks(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+        """Parse comma-separated CIDR strings into network objects."""
+        networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        if not raw:
+            return networks
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            try:
+                networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                logger.warning("Invalid trusted network CIDR, skipping", cidr=entry)
+        return networks
+
+    def _is_trusted_network(self, request: Request) -> bool:
+        """Check if the client IP falls within a trusted CIDR range."""
+        client_ip_str = self._get_client_ip(request)
+        if client_ip_str == "unknown":
+            return False
+        try:
+            client_ip = ipaddress.ip_address(client_ip_str)
+        except ValueError:
+            return False
+        return any(client_ip in network for network in self._trusted_networks)
 
     async def _authenticate_request(self, request: Request, scope: dict, *, api_key: str | None = None):
         """Handle API key authentication with rate limiting."""

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -16,6 +16,10 @@ from ..services.auth import get_auth_service
 
 logger = structlog.get_logger(__name__)
 
+# Max bytes to buffer when inspecting the request body for an API key.
+# Keeps memory bounded for unauthenticated requests (issue #59 review).
+_MAX_AUTH_BODY_BYTES = 1 * 1024 * 1024  # 1 MB
+
 
 class SecurityMiddleware:
     """Consolidated middleware for security, authentication, and headers."""
@@ -99,7 +103,12 @@ class SecurityMiddleware:
                 api_key = self._extract_api_key(request)
 
                 # If no key in headers, try JSON body extraction for POST/PUT/PATCH
-                if api_key is None and request.method in ("POST", "PUT", "PATCH"):
+                content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                if (
+                    api_key is None
+                    and request.method in ("POST", "PUT", "PATCH")
+                    and content_type == "application/json"
+                ):
                     body_bytes, receive = await self._buffer_body(receive)
                     api_key = self._extract_api_key_from_body(body_bytes)
 
@@ -269,10 +278,14 @@ class SecurityMiddleware:
         the middleware has inspected it.
         """
         body_parts: list[bytes] = []
+        total = 0
         while True:
             message = await receive()
             body = message.get("body", b"")
             if body:
+                total += len(body)
+                if total > _MAX_AUTH_BODY_BYTES:
+                    raise HTTPException(status_code=413, detail="Request body too large")
                 body_parts.append(body)
             if not message.get("more_body", False):
                 break

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -1,6 +1,7 @@
 """Consolidated security middleware for the Code Interpreter API."""
 
 # Standard library imports
+import json
 import time
 from typing import Callable, Optional
 
@@ -94,7 +95,15 @@ class SecurityMiddleware:
 
             # Handle authentication (skip for excluded paths and OPTIONS)
             if not self._should_skip_auth(request):
-                await self._authenticate_request(request, scope)
+                # Try header-based extraction first
+                api_key = self._extract_api_key(request)
+
+                # If no key in headers, try JSON body extraction for POST/PUT/PATCH
+                if api_key is None and request.method in ("POST", "PUT", "PATCH"):
+                    body_bytes, receive = await self._buffer_body(receive)
+                    api_key = self._extract_api_key_from_body(body_bytes)
+
+                await self._authenticate_request(request, scope, api_key=api_key)
 
         except HTTPException as e:
             response = JSONResponse(
@@ -146,10 +155,11 @@ class SecurityMiddleware:
             or request.method == "OPTIONS"
         )
 
-    async def _authenticate_request(self, request: Request, scope: dict):
+    async def _authenticate_request(self, request: Request, scope: dict, *, api_key: str | None = None):
         """Handle API key authentication with rate limiting."""
-        # Extract API key
-        api_key = self._extract_api_key(request)
+        # Use provided api_key or extract from headers as fallback
+        if api_key is None:
+            api_key = self._extract_api_key(request)
 
         # Get authentication service
         auth_service = await get_auth_service()
@@ -231,6 +241,55 @@ class SecurityMiddleware:
                 return auth_header[7:]
 
         return None
+
+    def _extract_api_key_from_body(self, body: bytes) -> str | None:
+        """Extract API key from JSON request body fields.
+
+        Supports @librechat/agents >=3.1.74 which spreads params into the
+        request body instead of sending the key as a header.
+        """
+        if not body:
+            return None
+        try:
+            data = json.loads(body)
+            if not isinstance(data, dict):
+                return None
+            for field in ("LIBRECHAT_CODE_API_KEY", "api_key", "apiKey"):
+                if key := data.get(field):
+                    if isinstance(key, str) and key.strip():
+                        return key.strip()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+        return None
+
+    async def _buffer_body(self, receive: Callable) -> tuple[bytes, Callable]:
+        """Read and buffer the request body, returning a replay receive callable.
+
+        This ensures the body remains available for downstream handlers after
+        the middleware has inspected it.
+        """
+        body_parts: list[bytes] = []
+        while True:
+            message = await receive()
+            body = message.get("body", b"")
+            if body:
+                body_parts.append(body)
+            if not message.get("more_body", False):
+                break
+
+        full_body = b"".join(body_parts)
+
+        # Create a replay receive that returns the buffered body
+        body_sent = False
+
+        async def replay_receive() -> dict:
+            nonlocal body_sent
+            if not body_sent:
+                body_sent = True
+                return {"type": "http.request", "body": full_body, "more_body": False}
+            return {"type": "http.disconnect"}
+
+        return full_body, replay_receive
 
     def _get_client_ip(self, request: Request) -> str:
         """Get client IP address."""

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -190,10 +190,14 @@ class SecurityMiddleware:
         return networks
 
     def _is_trusted_network(self, request: Request) -> bool:
-        """Check if the client IP falls within a trusted CIDR range."""
-        client_ip_str = self._get_client_ip(request)
-        if client_ip_str == "unknown":
+        """Check if the client IP falls within a trusted CIDR range.
+
+        Uses the actual socket peer address (request.client.host) rather than
+        forwarded headers to prevent IP spoofing attacks.
+        """
+        if not request.client:
             return False
+        client_ip_str = request.client.host
         try:
             client_ip = ipaddress.ip_address(client_ip_str)
         except ValueError:
@@ -205,6 +209,9 @@ class SecurityMiddleware:
         # Use provided api_key or extract from headers as fallback
         if api_key is None:
             api_key = self._extract_api_key(request)
+
+        if not api_key:
+            raise HTTPException(status_code=401, detail="Missing API key")
 
         # Get authentication service
         auth_service = await get_auth_service()

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -163,7 +163,7 @@ class PodPool:
                         "Unexpected error during pool warmup",
                         language=self.language,
                         error=str(result),
-                        exc_info=result,
+                        exc_info=(type(result), result, result.__traceback__),
                     )
 
     async def _create_warm_pod(self) -> PooledPod | None:
@@ -380,7 +380,7 @@ class PodPool:
                                     "Unexpected error during pool replenishment",
                                     language=self.language,
                                     error=str(result),
-                                    exc_info=result,
+                                    exc_info=(type(result), result, result.__traceback__),
                                 )
 
             except asyncio.CancelledError:

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -19,6 +19,7 @@ from .client import (
     create_pod_manifest,
     get_core_api,
     get_current_namespace,
+    get_initialization_error,
 )
 from .models import (
     ExecutionResult,
@@ -155,12 +156,25 @@ class PodPool:
         batch_size = min(needed, 5)
         for i in range(0, needed, batch_size):
             tasks = [self._create_warm_pod() for _ in range(min(batch_size, needed - i))]
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.error(
+                        "Unexpected error during pool warmup",
+                        language=self.language,
+                        error=str(result),
+                        exc_info=result,
+                    )
 
     async def _create_warm_pod(self) -> PooledPod | None:
         """Create a single warm pod."""
         core_api = get_core_api()
         if not core_api:
+            logger.error(
+                "Cannot create warm pod: Kubernetes client unavailable",
+                language=self.language,
+                init_error=get_initialization_error(),
+            )
             return None
 
         pod_name = self._generate_pod_name()
@@ -174,25 +188,25 @@ class PodPool:
             "kubecoderun.io/pool-status": "warm",
         }
 
-        pod_manifest = create_pod_manifest(
-            name=pod_name,
-            namespace=self.namespace,
-            main_image=self.config.image,
-            language=self.language,
-            labels=labels,
-            cpu_limit=self.config.cpu_limit or "1",
-            memory_limit=self.config.memory_limit or "512Mi",
-            image_pull_policy=self.config.image_pull_policy,
-            runner_port=8080,
-            seccomp_profile_type=self.config.seccomp_profile_type,
-            network_isolated=self.config.network_isolated,
-            runtime_class_name=self.config.runtime_class_name,
-            pod_node_selector=self.config.pod_node_selector,
-            pod_tolerations=self.config.pod_tolerations,
-            image_pull_secrets=self.config.image_pull_secrets,
-        )
-
         try:
+            pod_manifest = create_pod_manifest(
+                name=pod_name,
+                namespace=self.namespace,
+                main_image=self.config.image,
+                language=self.language,
+                labels=labels,
+                cpu_limit=self.config.cpu_limit or "1",
+                memory_limit=self.config.memory_limit or "512Mi",
+                image_pull_policy=self.config.image_pull_policy,
+                runner_port=8080,
+                seccomp_profile_type=self.config.seccomp_profile_type,
+                network_isolated=self.config.network_isolated,
+                runtime_class_name=self.config.runtime_class_name,
+                pod_node_selector=self.config.pod_node_selector,
+                pod_tolerations=self.config.pod_tolerations,
+                image_pull_secrets=self.config.image_pull_secrets,
+            )
+
             loop = asyncio.get_event_loop()
             pod = await loop.run_in_executor(
                 None,
@@ -211,6 +225,11 @@ class PodPool:
             # Wait for pod to be ready
             ready = await self._wait_for_pod_ready(handle)
             if not ready:
+                logger.warning(
+                    "Warm pod did not become ready, deleting",
+                    pod_name=pod_name,
+                    language=self.language,
+                )
                 await self._delete_pod(handle)
                 return None
 
@@ -235,9 +254,21 @@ class PodPool:
 
         except ApiException as e:
             logger.error(
-                "Failed to create warm pod",
+                "Failed to create warm pod (Kubernetes API error)",
                 pod_name=pod_name,
+                language=self.language,
+                status=e.status,
+                reason=e.reason,
                 error=str(e),
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                "Failed to create warm pod (unexpected error)",
+                pod_name=pod_name,
+                language=self.language,
+                error=str(e),
+                exc_info=True,
             )
             return None
 
@@ -342,7 +373,15 @@ class PodPool:
                     for i in range(0, needed, 5):
                         batch = min(5, needed - i)
                         tasks = [self._create_warm_pod() for _ in range(batch)]
-                        await asyncio.gather(*tasks, return_exceptions=True)
+                        results = await asyncio.gather(*tasks, return_exceptions=True)
+                        for result in results:
+                            if isinstance(result, BaseException):
+                                logger.error(
+                                    "Unexpected error during pool replenishment",
+                                    language=self.language,
+                                    error=str(result),
+                                    exc_info=result,
+                                )
 
             except asyncio.CancelledError:
                 break

--- a/tests/unit/test_auth_body_extraction.py
+++ b/tests/unit/test_auth_body_extraction.py
@@ -1,0 +1,398 @@
+"""Unit tests for body-based API key extraction (LibreChat agents >=3.1.74 compat).
+
+Tests cover resolve_api_key from all three input locations:
+1. X-API-Key header (existing, unchanged)
+2. Authorization: Bearer header (existing, unchanged)
+3. JSON body fields (new: LIBRECHAT_CODE_API_KEY, api_key, apiKey)
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.middleware.auth import AuthenticationMiddleware
+from src.middleware.security import SecurityMiddleware
+
+
+@pytest.fixture
+def mock_app():
+    """Create a mock ASGI app."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def auth_middleware(mock_app):
+    """Create auth middleware instance."""
+    return AuthenticationMiddleware(mock_app)
+
+
+@pytest.fixture
+def security_middleware(mock_app):
+    """Create security middleware instance."""
+    with patch("src.middleware.security.settings") as mock_settings:
+        mock_settings.max_file_size_mb = 10
+        return SecurityMiddleware(mock_app)
+
+
+class TestExtractApiKeyFromBody:
+    """Tests for _extract_api_key_from_body method on both middleware classes."""
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_extract_librechat_code_api_key(self, middleware_fixture, request):
+        """Test extraction from LIBRECHAT_CODE_API_KEY body field."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"lang": "py", "code": "print(1)", "LIBRECHAT_CODE_API_KEY": "my-secret-key"}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result == "my-secret-key"
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_extract_api_key_field(self, middleware_fixture, request):
+        """Test extraction from api_key body field."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"lang": "py", "code": "print(1)", "api_key": "another-key"}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result == "another-key"
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_extract_apikey_camel_case(self, middleware_fixture, request):
+        """Test extraction from apiKey body field (camelCase)."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"lang": "py", "code": "print(1)", "apiKey": "camel-key"}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result == "camel-key"
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_priority_librechat_over_api_key(self, middleware_fixture, request):
+        """Test LIBRECHAT_CODE_API_KEY takes priority over api_key."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps(
+            {
+                "LIBRECHAT_CODE_API_KEY": "priority-key",
+                "api_key": "fallback-key",
+                "apiKey": "last-key",
+            }
+        ).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result == "priority-key"
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_empty_body(self, middleware_fixture, request):
+        """Test empty body returns None."""
+        middleware = request.getfixturevalue(middleware_fixture)
+
+        result = middleware._extract_api_key_from_body(b"")
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_invalid_json(self, middleware_fixture, request):
+        """Test invalid JSON returns None."""
+        middleware = request.getfixturevalue(middleware_fixture)
+
+        result = middleware._extract_api_key_from_body(b"not json at all")
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_non_dict_json(self, middleware_fixture, request):
+        """Test non-dict JSON (e.g. array) returns None."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps(["not", "a", "dict"]).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_no_key_fields_in_body(self, middleware_fixture, request):
+        """Test body without any key fields returns None."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"lang": "py", "code": "print(1)", "user_id": "user123"}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_whitespace_only_key_ignored(self, middleware_fixture, request):
+        """Test whitespace-only key values are ignored."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"api_key": "   "}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_non_string_key_ignored(self, middleware_fixture, request):
+        """Test non-string key values are ignored."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"api_key": 12345}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result is None
+
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    def test_key_value_stripped(self, middleware_fixture, request):
+        """Test key values are stripped of whitespace."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body = json.dumps({"api_key": "  my-key  "}).encode()
+
+        result = middleware._extract_api_key_from_body(body)
+
+        assert result == "my-key"
+
+
+class TestBufferBody:
+    """Tests for _buffer_body method on both middleware classes."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    async def test_buffer_single_chunk(self, middleware_fixture, request):
+        """Test buffering a single-chunk body."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body_content = b'{"lang": "py", "code": "print(1)"}'
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_content, "more_body": False}
+
+        result_body, replay = await middleware._buffer_body(mock_receive)
+
+        assert result_body == body_content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    async def test_buffer_multi_chunk(self, middleware_fixture, request):
+        """Test buffering a multi-chunk body."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        chunks = [
+            {"type": "http.request", "body": b'{"lang": ', "more_body": True},
+            {"type": "http.request", "body": b'"py", "code":', "more_body": True},
+            {"type": "http.request", "body": b' "print(1)"}', "more_body": False},
+        ]
+        chunk_iter = iter(chunks)
+
+        async def mock_receive():
+            return next(chunk_iter)
+
+        result_body, replay = await middleware._buffer_body(mock_receive)
+
+        assert result_body == b'{"lang": "py", "code": "print(1)"}'
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    async def test_replay_receive_returns_buffered_body(self, middleware_fixture, request):
+        """Test replay receive returns the buffered body on first call."""
+        middleware = request.getfixturevalue(middleware_fixture)
+        body_content = b'{"api_key": "test-key"}'
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_content, "more_body": False}
+
+        _, replay = await middleware._buffer_body(mock_receive)
+
+        # First call returns the body
+        msg = await replay()
+        assert msg["type"] == "http.request"
+        assert msg["body"] == body_content
+        assert msg["more_body"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    async def test_replay_receive_disconnects_after_body(self, middleware_fixture, request):
+        """Test replay receive returns disconnect after body is consumed."""
+        middleware = request.getfixturevalue(middleware_fixture)
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"data", "more_body": False}
+
+        _, replay = await middleware._buffer_body(mock_receive)
+
+        # First call: body
+        await replay()
+        # Second call: disconnect
+        msg = await replay()
+        assert msg["type"] == "http.disconnect"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("middleware_fixture", ["auth_middleware", "security_middleware"])
+    async def test_buffer_empty_body(self, middleware_fixture, request):
+        """Test buffering an empty body."""
+        middleware = request.getfixturevalue(middleware_fixture)
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        result_body, replay = await middleware._buffer_body(mock_receive)
+
+        assert result_body == b""
+
+
+class TestFullAuthFlowWithBodyKey:
+    """Integration-style tests for the full auth flow with body-based keys."""
+
+    @pytest.mark.asyncio
+    async def test_auth_middleware_body_key_accepted(self, auth_middleware, mock_app):
+        """Test AuthenticationMiddleware accepts API key from body."""
+        body = json.dumps({"lang": "py", "code": "print(1)", "api_key": "valid-key"}).encode()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.auth.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_service.validate_api_key.return_value = True
+            mock_get_auth.return_value = mock_service
+
+            await auth_middleware(scope, mock_receive, mock_send)
+
+        # App should have been called (auth passed)
+        mock_app.assert_called_once()
+        # Verify the key was extracted from body
+        mock_service.validate_api_key.assert_called_once_with("valid-key")
+
+    @pytest.mark.asyncio
+    async def test_auth_middleware_header_key_preferred_over_body(self, auth_middleware, mock_app):
+        """Test header key takes priority over body key."""
+        body = json.dumps({"api_key": "body-key"}).encode()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"x-api-key", b"header-key"), (b"content-type", b"application/json")],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.auth.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_service.validate_api_key.return_value = True
+            mock_get_auth.return_value = mock_service
+
+            await auth_middleware(scope, mock_receive, mock_send)
+
+        # Header key should be used, not body key
+        mock_service.validate_api_key.assert_called_once_with("header-key")
+
+    @pytest.mark.asyncio
+    async def test_auth_middleware_no_key_anywhere_returns_401(self, auth_middleware):
+        """Test 401 when no API key in headers or body."""
+        body = json.dumps({"lang": "py", "code": "print(1)"}).encode()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.auth.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_service.validate_api_key.return_value = False
+            mock_get_auth.return_value = mock_service
+
+            await auth_middleware(scope, mock_receive, mock_send)
+
+        # Should have sent a 401 response
+        mock_send.assert_called()
+        # Find the response start message
+        for call in mock_send.call_args_list:
+            msg = call[0][0]
+            if msg.get("type") == "http.response.start":
+                assert msg["status"] == 401
+                break
+
+    @pytest.mark.asyncio
+    async def test_security_middleware_body_key_accepted(self, security_middleware, mock_app):
+        """Test SecurityMiddleware accepts API key from body."""
+        body = json.dumps({"lang": "py", "code": "print(1)", "LIBRECHAT_CODE_API_KEY": "valid-key"}).encode()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.security.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_result = MagicMock()
+            mock_result.is_valid = True
+            mock_result.rate_limit_exceeded = False
+            mock_result.key_hash = "hash123"
+            mock_result.is_env_key = False
+            mock_service.validate_api_key_full.return_value = mock_result
+            mock_service.record_usage = AsyncMock()
+            mock_get_auth.return_value = mock_service
+
+            await security_middleware(scope, mock_receive, mock_send)
+
+        # App should have been called (auth passed)
+        mock_app.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_request_does_not_buffer_body(self, auth_middleware, mock_app):
+        """Test GET requests don't attempt body extraction."""
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"x-api-key", b"valid-key")],
+        }
+
+        mock_receive = AsyncMock()
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.auth.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_service.validate_api_key.return_value = True
+            mock_get_auth.return_value = mock_service
+
+            await auth_middleware(scope, mock_receive, mock_send)
+
+        # receive should NOT have been called (no body buffering for GET)
+        mock_receive.assert_not_called()
+        mock_app.assert_called_once()

--- a/tests/unit/test_auth_body_extraction.py
+++ b/tests/unit/test_auth_body_extraction.py
@@ -33,6 +33,7 @@ def security_middleware(mock_app):
     """Create security middleware instance."""
     with patch("src.middleware.security.settings") as mock_settings:
         mock_settings.max_file_size_mb = 10
+        mock_settings.auth_trusted_networks = ""
         return SecurityMiddleware(mock_app)
 
 

--- a/tests/unit/test_auth_body_extraction.py
+++ b/tests/unit/test_auth_body_extraction.py
@@ -10,6 +10,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from src.middleware.auth import AuthenticationMiddleware
 from src.middleware.security import SecurityMiddleware
@@ -396,3 +397,130 @@ class TestFullAuthFlowWithBodyKey:
         # receive should NOT have been called (no body buffering for GET)
         mock_receive.assert_not_called()
         mock_app.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auth_middleware_skips_body_for_non_json_content_type(self, auth_middleware, mock_app):
+        """Test body extraction is skipped for non-JSON content types (e.g. multipart)."""
+        body = json.dumps({"api_key": "body-key"}).encode()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"content-type", b"multipart/form-data; boundary=abc")],
+        }
+
+        mock_receive = AsyncMock()
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.auth.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_service.validate_api_key.return_value = False
+            mock_get_auth.return_value = mock_service
+
+            await auth_middleware(scope, mock_receive, mock_send)
+
+        # Body should NOT have been buffered (non-JSON content type)
+        mock_receive.assert_not_called()
+        # Should have sent a 401 response (no key found in headers)
+        mock_send.assert_called()
+        for call in mock_send.call_args_list:
+            msg = call[0][0]
+            if msg.get("type") == "http.response.start":
+                assert msg["status"] == 401
+                break
+
+    @pytest.mark.asyncio
+    async def test_security_middleware_skips_body_for_non_json_content_type(self, security_middleware):
+        """Test SecurityMiddleware skips body extraction for non-JSON content types."""
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [(b"content-type", b"text/plain")],
+        }
+
+        mock_receive = AsyncMock()
+        mock_send = AsyncMock()
+
+        with patch("src.middleware.security.get_auth_service") as mock_get_auth:
+            mock_service = AsyncMock()
+            mock_service.check_rate_limit.return_value = True
+            mock_result = MagicMock()
+            mock_result.is_valid = False
+            mock_result.error_message = "Invalid or missing API key"
+            mock_service.validate_api_key_full.return_value = mock_result
+            mock_get_auth.return_value = mock_service
+
+            await security_middleware(scope, mock_receive, mock_send)
+
+        # Body should NOT have been buffered
+        mock_receive.assert_not_called()
+
+
+class TestBufferBodySizeLimit:
+    """Tests for body size limit enforcement in _buffer_body."""
+
+    @pytest.mark.asyncio
+    async def test_auth_buffer_body_rejects_oversized_payload(self, auth_middleware):
+        """Test _buffer_body raises 413 for payloads exceeding the size limit."""
+        from src.middleware.auth import _MAX_AUTH_BODY_BYTES
+
+        oversized_chunk = b"x" * (_MAX_AUTH_BODY_BYTES + 1)
+
+        async def mock_receive():
+            return {"type": "http.request", "body": oversized_chunk, "more_body": False}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_middleware._buffer_body(mock_receive)
+
+        assert exc_info.value.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_security_buffer_body_rejects_oversized_payload(self, security_middleware):
+        """Test _buffer_body raises 413 for payloads exceeding the size limit."""
+        from src.middleware.security import _MAX_AUTH_BODY_BYTES
+
+        oversized_chunk = b"x" * (_MAX_AUTH_BODY_BYTES + 1)
+
+        async def mock_receive():
+            return {"type": "http.request", "body": oversized_chunk, "more_body": False}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await security_middleware._buffer_body(mock_receive)
+
+        assert exc_info.value.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_auth_buffer_body_rejects_oversized_multi_chunk(self, auth_middleware):
+        """Test _buffer_body rejects multi-chunk payloads that exceed the limit."""
+        from src.middleware.auth import _MAX_AUTH_BODY_BYTES
+
+        chunk_size = _MAX_AUTH_BODY_BYTES // 2 + 1
+        chunks = [
+            {"type": "http.request", "body": b"x" * chunk_size, "more_body": True},
+            {"type": "http.request", "body": b"x" * chunk_size, "more_body": False},
+        ]
+        chunk_iter = iter(chunks)
+
+        async def mock_receive():
+            return next(chunk_iter)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_middleware._buffer_body(mock_receive)
+
+        assert exc_info.value.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_buffer_body_accepts_payload_within_limit(self, auth_middleware):
+        """Test _buffer_body accepts payloads within the size limit."""
+        body = b'{"api_key": "test-key"}'
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        result_body, _ = await auth_middleware._buffer_body(mock_receive)
+        assert result_body == body

--- a/tests/unit/test_trusted_networks.py
+++ b/tests/unit/test_trusted_networks.py
@@ -29,16 +29,12 @@ def _make_request(client_ip: str = "10.0.0.1", path: str = "/exec", method: str 
         "headers": [],
         "query_string": b"",
         "root_path": "",
+        "client": (client_ip, 12345),
     }
     request = Request(scope)
     request._url = MagicMock()
     request._url.path = path
-    # Mock client
-    request._client = MagicMock()
-    request._client.host = client_ip
-    # Patch scope client for Request.client property
-    scope["client"] = (client_ip, 12345)
-    return Request(scope)
+    return request
 
 
 class TestParseNetworks:

--- a/tests/unit/test_trusted_networks.py
+++ b/tests/unit/test_trusted_networks.py
@@ -1,0 +1,192 @@
+"""Unit tests for trusted networks auth bypass.
+
+Tests cover the AUTH_TRUSTED_NETWORKS feature that allows requests from
+configured CIDRs to bypass API key authentication (e.g. in-cluster callers).
+"""
+
+import ipaddress
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+
+from src.middleware.auth import AuthenticationMiddleware
+from src.middleware.security import SecurityMiddleware
+
+
+@pytest.fixture
+def mock_app():
+    """Create a mock ASGI app."""
+    return AsyncMock()
+
+
+def _make_request(client_ip: str = "10.0.0.1", path: str = "/exec", method: str = "POST") -> Request:
+    """Create a mock Request with the given client IP."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "root_path": "",
+    }
+    request = Request(scope)
+    request._url = MagicMock()
+    request._url.path = path
+    # Mock client
+    request._client = MagicMock()
+    request._client.host = client_ip
+    # Patch scope client for Request.client property
+    scope["client"] = (client_ip, 12345)
+    return Request(scope)
+
+
+class TestParseNetworks:
+    """Tests for _parse_trusted_networks static method."""
+
+    def test_empty_string(self):
+        result = SecurityMiddleware._parse_trusted_networks("")
+        assert result == []
+
+    def test_single_cidr(self):
+        result = SecurityMiddleware._parse_trusted_networks("10.0.0.0/8")
+        assert len(result) == 1
+        assert result[0] == ipaddress.ip_network("10.0.0.0/8")
+
+    def test_multiple_cidrs(self):
+        result = SecurityMiddleware._parse_trusted_networks("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16")
+        assert len(result) == 3
+
+    def test_whitespace_handling(self):
+        result = SecurityMiddleware._parse_trusted_networks(" 10.0.0.0/8 , 172.16.0.0/12 ")
+        assert len(result) == 2
+
+    def test_trailing_comma(self):
+        result = SecurityMiddleware._parse_trusted_networks("10.0.0.0/8,")
+        assert len(result) == 1
+
+    def test_invalid_cidr_skipped(self):
+        result = SecurityMiddleware._parse_trusted_networks("10.0.0.0/8,not-a-cidr,172.16.0.0/12")
+        assert len(result) == 2
+
+    def test_single_host_cidr(self):
+        result = SecurityMiddleware._parse_trusted_networks("240.3.25.75/32")
+        assert len(result) == 1
+        assert ipaddress.ip_address("240.3.25.75") in result[0]
+
+    def test_ipv6_cidr(self):
+        result = SecurityMiddleware._parse_trusted_networks("fd00::/8")
+        assert len(result) == 1
+
+    def test_class_e_range(self):
+        """The LibreChat pod IP 240.3.25.75 falls in Class E (240.0.0.0/4)."""
+        result = SecurityMiddleware._parse_trusted_networks("240.0.0.0/4")
+        assert len(result) == 1
+        assert ipaddress.ip_address("240.3.25.75") in result[0]
+
+
+class TestIsTrustedNetwork:
+    """Tests for _is_trusted_network method."""
+
+    def test_ip_in_trusted_range(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="10.1.2.3")
+        assert mw._is_trusted_network(request) is True
+
+    def test_ip_not_in_trusted_range(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="192.168.1.1")
+        assert mw._is_trusted_network(request) is False
+
+    def test_unknown_ip_not_trusted(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        # Simulate unknown client
+        scope = {"type": "http", "method": "POST", "path": "/exec", "headers": [], "query_string": b"", "root_path": ""}
+        request = Request(scope)
+        assert mw._is_trusted_network(request) is False
+
+    def test_librechat_pod_ip_trusted(self, mock_app):
+        """Real-world scenario: LibreChat pod at 240.3.25.75 with 240.0.0.0/4 trusted."""
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "240.0.0.0/4,10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="240.3.25.75")
+        assert mw._is_trusted_network(request) is True
+
+    def test_no_trusted_networks_configured(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = ""
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="10.0.0.1")
+        assert mw._is_trusted_network(request) is False
+
+
+class TestShouldSkipAuth:
+    """Tests for _should_skip_auth with trusted networks."""
+
+    def test_trusted_ip_skips_auth(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="10.1.2.3", path="/exec")
+        assert mw._should_skip_auth(request) is True
+
+    def test_untrusted_ip_requires_auth(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="203.0.113.1", path="/exec")
+        assert mw._should_skip_auth(request) is False
+
+    def test_excluded_path_still_skips(self, mock_app):
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 10
+            mock_settings.auth_trusted_networks = ""
+            mw = SecurityMiddleware(mock_app)
+
+        request = _make_request(client_ip="203.0.113.1", path="/health")
+        assert mw._should_skip_auth(request) is True
+
+
+class TestAuthMiddlewareTrustedNetworks:
+    """Tests for AuthenticationMiddleware trusted network handling."""
+
+    def test_parse_networks(self):
+        result = AuthenticationMiddleware._parse_trusted_networks("10.0.0.0/8,172.16.0.0/12")
+        assert len(result) == 2
+
+    def test_trusted_ip_skips_auth(self, mock_app):
+        with patch("src.middleware.auth.settings") as mock_settings:
+            mock_settings.auth_trusted_networks = "240.0.0.0/4"
+            mw = AuthenticationMiddleware(mock_app)
+
+        request = _make_request(client_ip="240.3.25.75", path="/exec")
+        assert mw._should_skip_auth(request) is True
+
+    def test_untrusted_ip_requires_auth(self, mock_app):
+        with patch("src.middleware.auth.settings") as mock_settings:
+            mock_settings.auth_trusted_networks = "240.0.0.0/4"
+            mw = AuthenticationMiddleware(mock_app)
+
+        request = _make_request(client_ip="8.8.8.8", path="/exec")
+        assert mw._should_skip_auth(request) is False


### PR DESCRIPTION
### Problem
On LibreChat v0.8.5, `@librechat/agents` 3.1.74 silently removed the `X-API-Key` header from outbound requests to KubeCodeRun, spreading params into the JSON body instead. This causes **401 Unauthorized** on every `execute_code` tool invocation.

### Solution
This PR introduces the following changes:

1. **API Key Extraction**:
   - Adds body-based API key extraction as a fallback in both `AuthenticationMiddleware` and `SecurityMiddleware`. The key resolution priority is:
     - `X-API-Key` header (existing, unchanged — agents ≤3.1.73)
     - `Authorization: Bearer` header (existing, unchanged)
     - JSON body fields: `LIBRECHAT_CODE_API_KEY`, `api_key`, `apiKey` (new)
   - Body extraction only triggers for `POST`/`PUT`/`PATCH` when no header key is found. A buffer-and-replay pattern ensures the request body remains available for downstream route handlers.

2. **Trusted Networks Bypass**:
   - Adds a feature to bypass authentication for trusted networks within the cluster, improving compatibility for in-cluster callers.

3. **Error Handling and Logging**:
   - Improves error handling and logging during warm pod creation and replenishment, making debugging easier.

4. **Request Body Size Limit**:
   - Enforces a limit on the request body size to prevent potential abuse or resource exhaustion.

### Testing
- 37 new unit tests covering all extraction paths, body buffering, replay semantics, priority ordering, and edge cases.
- All existing auth/security middleware tests pass (zero regressions).
- Lint (`ruff check`) and format (`ruff format --check`) pass cleanly.
- No conflicts with `feat-pod-labels-config` branch (verified via merge dry-run).

### Security
- No API key values logged.
- Existing constant-time comparison via `AuthenticationService.validate_api_key` unchanged.
- Body parsing is read-only; does not consume the stream for downstream handlers.