### PR TITLE
feat(k8s): add configurable extra pod labels with optional language suffix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,13 @@ METRICS_ARCHIVE_RETENTION_DAYS=90
 # K8S_POD_NODE_SELECTOR={"sandbox":"true"}
 # K8S_POD_TOLERATIONS=[{"key":"sandbox","operator":"Exists","effect":"NoSchedule"}]
 
+# Custom Pod Labels
+# JSON-encoded extra labels applied to all execution pods.
+# K8S_POD_LABELS={"example.com/workload-type":"CodeRunner","example.com/workload-name":"MyApp"}
+# JSON-encoded list of label keys from K8S_POD_LABELS whose values get "-<lang>" appended
+# (e.g. "MyApp" becomes "MyApp-py" for Python pods). Optional — omit to skip suffixing.
+# K8S_POD_LABEL_LANGUAGE_SUFFIX=["example.com/workload-name"]
+
 # Security Configuration
 ENABLE_NETWORK_ISOLATION=true
 ENABLE_FILESYSTEM_ISOLATION=true

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -182,6 +182,11 @@ Kubernetes is used for secure code execution in isolated pods.
 | `K8S_MEMORY_LIMIT`     | `512Mi`                                      | Memory limit per execution pod           |
 | `K8S_CPU_REQUEST`      | `100m`                                       | CPU request per execution pod            |
 | `K8S_MEMORY_REQUEST`   | `128Mi`                                      | Memory request per execution pod         |
+| `K8S_RUNTIME_CLASS_NAME` | `""`                                       | RuntimeClassName for execution pods (e.g. `gvisor`, `kata`). Empty = cluster default |
+| `K8S_POD_NODE_SELECTOR` | `""`                                        | JSON-encoded node selector for execution pods (e.g. `{"sandbox":"true"}`) |
+| `K8S_POD_TOLERATIONS`  | `""`                                         | JSON-encoded tolerations for execution pods |
+| `K8S_POD_LABELS`       | `""`                                         | JSON-encoded extra labels for execution pods (e.g. `{"team":"platform"}`) |
+| `K8S_POD_LABEL_LANGUAGE_SUFFIX` | `""`                                | JSON-encoded list of label keys whose values get `-<lang>` appended (optional) |
 
 **Security Notes:**
 
@@ -191,6 +196,21 @@ Kubernetes is used for secure code execution in isolated pods.
 - Network policies deny all egress by default
 - Pods are destroyed immediately after execution
 - See [SECURITY.md](SECURITY.md) for the full security model
+
+**Custom Pod Labels:**
+
+`K8S_POD_LABELS` lets you attach extra Kubernetes labels to every execution pod (pool and job).
+`K8S_POD_LABEL_LANGUAGE_SUFFIX` optionally lists label keys whose values get the language code
+appended with a `-` separator (e.g. `MyApp` → `MyApp-py`). Labels under `app.kubernetes.io/*`
+and `kubecoderun.io/*` prefixes are protected and cannot be overridden. Unmatched suffix keys
+produce a warning in the API logs but do not prevent startup.
+
+```bash
+# Example
+K8S_POD_LABELS='{"example.com/workload-type":"CodeRunner","example.com/workload-name":"MyApp"}'
+K8S_POD_LABEL_LANGUAGE_SUFFIX='["example.com/workload-name"]'
+# → Python pod gets: example.com/workload-name=MyApp-py
+```
 
 ### Resource Limits
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -183,6 +183,14 @@ class Settings(BaseSettings):
         default="",
         description='JSON-encoded tolerations for execution pods (e.g. \'[{"key":"sandbox","operator":"Exists","effect":"NoSchedule"}]\')',
     )
+    k8s_pod_labels: str = Field(
+        default="",
+        description='JSON-encoded extra labels for execution pods (e.g. \'{"team":"platform"}\')',
+    )
+    k8s_pod_label_language_suffix: str = Field(
+        default="",
+        description='JSON-encoded list of label keys from K8S_POD_LABELS that get "-<lang>" appended (e.g. \'["workload-name"]\')',
+    )
 
     # Resource Limits - Execution
     max_execution_time: int = Field(default=30, ge=1, le=600)
@@ -663,6 +671,8 @@ class Settings(BaseSettings):
                     pod_node_selector=self.k8s_pod_node_selector,
                     pod_tolerations=self.k8s_pod_tolerations,
                     image_pull_secrets=self.k8s_image_pull_secrets,
+                    pod_labels=self.k8s_pod_labels,
+                    pod_label_language_suffix=self.k8s_pod_label_language_suffix,
                 )
             )
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -616,6 +616,8 @@ class Settings(BaseSettings):
             runtime_class_name=self.k8s_runtime_class_name,
             pod_node_selector=self.k8s_pod_node_selector,
             pod_tolerations=self.k8s_pod_tolerations,
+            pod_labels=self.k8s_pod_labels,
+            pod_label_language_suffix=self.k8s_pod_label_language_suffix,
         )
 
     def get_pool_configs(self):

--- a/src/config/kubernetes.py
+++ b/src/config/kubernetes.py
@@ -34,6 +34,10 @@ class KubernetesConfig:
     pod_node_selector: str = ""  # JSON-encoded dict, e.g. '{"sandbox": "true"}'
     pod_tolerations: str = ""  # JSON-encoded list, e.g. '[{"key":"sandbox","operator":"Exists","effect":"NoSchedule"}]'
 
+    # Extra pod labels (JSON-encoded dict) and language-suffix keys (JSON-encoded list)
+    pod_labels: str = ""  # e.g. '{"team":"platform"}'
+    pod_label_language_suffix: str = ""  # e.g. '["team"]' → appends "-py", "-js", etc.
+
     # Job settings (for languages with pool_size=0)
     job_ttl_seconds_after_finished: int = 60
     job_active_deadline_seconds: int = 300

--- a/src/main.py
+++ b/src/main.py
@@ -156,6 +156,8 @@ async def lifespan(app: FastAPI):
                 pod_node_selector=settings.k8s_pod_node_selector,
                 pod_tolerations=settings.k8s_pod_tolerations,
                 image_pull_secrets=settings.k8s_image_pull_secrets,
+                pod_labels=settings.k8s_pod_labels,
+                pod_label_language_suffix=settings.k8s_pod_label_language_suffix,
             )
 
             await kubernetes_manager.start()

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -23,6 +23,61 @@ logger = structlog.get_logger(__name__)
 _PROTECTED_LABEL_PREFIXES = ("app.kubernetes.io/", "kubecoderun.io/")
 
 
+@lru_cache(maxsize=1)
+def _parse_and_validate_label_config(
+    pod_labels: str,
+    pod_label_language_suffix: str,
+) -> tuple[dict[str, str], list[str]]:
+    """Parse and validate label JSON config once, caching the result.
+
+    Returns:
+        Tuple of (validated labels dict, validated suffix keys list).
+    """
+    labels: dict[str, str] = {}
+    suffix_keys: list[str] = []
+
+    if pod_labels:
+        try:
+            parsed = json.loads(pod_labels)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid K8S_POD_LABELS JSON, ignoring", raw=pod_labels)
+            return {}, []
+
+        if not isinstance(parsed, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+        ):
+            logger.warning(
+                "Invalid K8S_POD_LABELS value, expected JSON dict of string→string, ignoring",
+                raw=pod_labels,
+            )
+            return {}, []
+        labels = parsed
+
+    if pod_label_language_suffix:
+        try:
+            parsed_suffix = json.loads(pod_label_language_suffix)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid K8S_POD_LABEL_LANGUAGE_SUFFIX JSON, ignoring", raw=pod_label_language_suffix)
+        else:
+            if isinstance(parsed_suffix, list) and all(isinstance(item, str) for item in parsed_suffix):
+                suffix_keys = parsed_suffix
+            else:
+                logger.warning(
+                    "Invalid K8S_POD_LABEL_LANGUAGE_SUFFIX value, expected JSON list of strings, ignoring",
+                    raw=pod_label_language_suffix,
+                )
+
+    # Warn about suffix keys that don't match any label (logged once at config parse time)
+    for suffix_key in suffix_keys:
+        if suffix_key not in labels:
+            logger.warning(
+                "K8S_POD_LABEL_LANGUAGE_SUFFIX key not found in K8S_POD_LABELS, ignoring",
+                suffix_key=suffix_key,
+            )
+
+    return labels, suffix_keys
+
+
 def build_custom_labels(
     pod_labels: str,
     pod_label_language_suffix: str,
@@ -30,8 +85,9 @@ def build_custom_labels(
 ) -> dict[str, str]:
     """Build custom labels from JSON-encoded config, applying language suffix where requested.
 
-    Protected label prefixes (app.kubernetes.io/*, kubecoderun.io/*) are silently
-    dropped to prevent accidental override of internal labels.
+    Protected label prefixes (app.kubernetes.io/*, kubecoderun.io/*) are dropped
+    to prevent accidental override of internal labels, and a warning is logged
+    when such labels are blocked.
 
     Args:
         pod_labels: JSON-encoded dict of extra labels (may be empty).
@@ -45,26 +101,9 @@ def build_custom_labels(
     if not pod_labels:
         return {}
 
-    try:
-        labels: dict[str, str] = json.loads(pod_labels)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Invalid K8S_POD_LABELS JSON, ignoring", raw=pod_labels)
+    labels, suffix_keys = _parse_and_validate_label_config(pod_labels, pod_label_language_suffix)
+    if not labels:
         return {}
-
-    suffix_keys: list[str] = []
-    if pod_label_language_suffix:
-        try:
-            suffix_keys = json.loads(pod_label_language_suffix)
-        except (json.JSONDecodeError, TypeError):
-            logger.warning("Invalid K8S_POD_LABEL_LANGUAGE_SUFFIX JSON, ignoring", raw=pod_label_language_suffix)
-
-    # Warn about suffix keys that don't match any label
-    for suffix_key in suffix_keys:
-        if suffix_key not in labels:
-            logger.warning(
-                "K8S_POD_LABEL_LANGUAGE_SUFFIX key not found in K8S_POD_LABELS, ignoring",
-                suffix_key=suffix_key,
-            )
 
     result: dict[str, str] = {}
     for key, value in labels.items():

--- a/src/services/kubernetes/client.py
+++ b/src/services/kubernetes/client.py
@@ -4,6 +4,7 @@ Provides configured Kubernetes API clients for pod and job management.
 Supports both in-cluster and out-of-cluster (kubeconfig) authentication.
 """
 
+import json
 import os
 from functools import lru_cache
 from typing import Optional, Tuple
@@ -17,6 +18,65 @@ from kubernetes.client import (
 )
 
 logger = structlog.get_logger(__name__)
+
+# Label key prefixes that cannot be overridden by custom pod labels
+_PROTECTED_LABEL_PREFIXES = ("app.kubernetes.io/", "kubecoderun.io/")
+
+
+def build_custom_labels(
+    pod_labels: str,
+    pod_label_language_suffix: str,
+    language: str,
+) -> dict[str, str]:
+    """Build custom labels from JSON-encoded config, applying language suffix where requested.
+
+    Protected label prefixes (app.kubernetes.io/*, kubecoderun.io/*) are silently
+    dropped to prevent accidental override of internal labels.
+
+    Args:
+        pod_labels: JSON-encoded dict of extra labels (may be empty).
+        pod_label_language_suffix: JSON-encoded list of label keys whose
+            values should be suffixed with ``-<language>`` (may be empty).
+        language: Language code as-is (e.g. ``py``, ``js``).
+
+    Returns:
+        Dict of custom labels ready to merge.
+    """
+    if not pod_labels:
+        return {}
+
+    try:
+        labels: dict[str, str] = json.loads(pod_labels)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Invalid K8S_POD_LABELS JSON, ignoring", raw=pod_labels)
+        return {}
+
+    suffix_keys: list[str] = []
+    if pod_label_language_suffix:
+        try:
+            suffix_keys = json.loads(pod_label_language_suffix)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Invalid K8S_POD_LABEL_LANGUAGE_SUFFIX JSON, ignoring", raw=pod_label_language_suffix)
+
+    # Warn about suffix keys that don't match any label
+    for suffix_key in suffix_keys:
+        if suffix_key not in labels:
+            logger.warning(
+                "K8S_POD_LABEL_LANGUAGE_SUFFIX key not found in K8S_POD_LABELS, ignoring",
+                suffix_key=suffix_key,
+            )
+
+    result: dict[str, str] = {}
+    for key, value in labels.items():
+        if any(key.startswith(prefix) for prefix in _PROTECTED_LABEL_PREFIXES):
+            logger.warning("Custom label blocked: protected prefix", label_key=key)
+            continue
+        if key in suffix_keys:
+            value = f"{value}-{language}"
+        result[key] = value
+
+    return result
+
 
 # Global client instances
 _core_api: CoreV1Api | None = None

--- a/src/services/kubernetes/job_executor.py
+++ b/src/services/kubernetes/job_executor.py
@@ -14,6 +14,7 @@ import structlog
 from kubernetes.client import ApiException
 
 from .client import (
+    build_custom_labels,
     create_job_manifest,
     get_batch_api,
     get_core_api,
@@ -101,6 +102,11 @@ class JobExecutor:
             "kubecoderun.io/session-id": session_id[:63],
             "kubecoderun.io/type": "job",
             **spec.labels,
+            **build_custom_labels(
+                spec.pod_labels,
+                spec.pod_label_language_suffix,
+                spec.language,
+            ),
         }
 
         job_manifest = create_job_manifest(

--- a/src/services/kubernetes/manager.py
+++ b/src/services/kubernetes/manager.py
@@ -51,6 +51,8 @@ class KubernetesManager:
         pod_node_selector: str = "",
         pod_tolerations: str = "",
         image_pull_secrets: str = "",
+        pod_labels: str = "",
+        pod_label_language_suffix: str = "",
     ):
         """Initialize the Kubernetes manager.
 
@@ -66,6 +68,8 @@ class KubernetesManager:
             runtime_class_name: Optional RuntimeClassName for pod sandboxing (e.g. gvisor, kata)
             pod_node_selector: JSON-encoded node selector labels for execution pods
             pod_tolerations: JSON-encoded tolerations for execution pods
+            pod_labels: JSON-encoded extra labels for execution pods
+            pod_label_language_suffix: JSON-encoded list of label keys that get "-<lang>" appended
         """
         self.namespace = namespace or get_current_namespace()
         self.default_cpu_limit = default_cpu_limit
@@ -78,6 +82,8 @@ class KubernetesManager:
         self.pod_node_selector = pod_node_selector
         self.pod_tolerations = pod_tolerations
         self.image_pull_secrets = image_pull_secrets
+        self.pod_labels = pod_labels
+        self.pod_label_language_suffix = pod_label_language_suffix
 
         # Pool manager for warm pods
         self._pool_manager = PodPoolManager(
@@ -290,6 +296,8 @@ class KubernetesManager:
                 pod_node_selector=self.pod_node_selector,
                 pod_tolerations=self.pod_tolerations,
                 image_pull_secrets=self.image_pull_secrets,
+                pod_labels=self.pod_labels,
+                pod_label_language_suffix=self.pod_label_language_suffix,
             )
 
             result = await self._job_executor.execute_with_job(

--- a/src/services/kubernetes/models.py
+++ b/src/services/kubernetes/models.py
@@ -127,6 +127,10 @@ class PodSpec:
     # Image pull secrets for private registries
     image_pull_secrets: str = ""  # Comma-separated secret names
 
+    # Extra pod labels and language-suffix keys
+    pod_labels: str = ""  # JSON-encoded dict
+    pod_label_language_suffix: str = ""  # JSON-encoded list of keys to suffix with "-<lang>"
+
 
 @dataclass
 class PoolConfig:
@@ -156,6 +160,10 @@ class PoolConfig:
 
     # Image pull secrets for private registries
     image_pull_secrets: str = ""  # Comma-separated secret names
+
+    # Extra pod labels and language-suffix keys
+    pod_labels: str = ""  # JSON-encoded dict
+    pod_label_language_suffix: str = ""  # JSON-encoded list of keys to suffix with "-<lang>"
 
     @property
     def uses_pool(self) -> bool:

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -16,6 +16,7 @@ import structlog
 from kubernetes.client import ApiException
 
 from .client import (
+    build_custom_labels,
     create_pod_manifest,
     get_core_api,
     get_current_namespace,
@@ -186,6 +187,11 @@ class PodPool:
             "kubecoderun.io/language": self.language,
             "kubecoderun.io/type": "pool",
             "kubecoderun.io/pool-status": "warm",
+            **build_custom_labels(
+                self.config.pod_labels,
+                self.config.pod_label_language_suffix,
+                self.language,
+            ),
         }
 
         try:

--- a/tests/unit/test_kubernetes_client.py
+++ b/tests/unit/test_kubernetes_client.py
@@ -542,6 +542,9 @@ class TestCreatePodManifest:
 class TestBuildCustomLabels:
     """Tests for build_custom_labels function."""
 
+    def setup_method(self):
+        client._parse_and_validate_label_config.cache_clear()
+
     def test_empty_pod_labels_returns_empty(self):
         result = client.build_custom_labels("", "", "py")
         assert result == {}
@@ -599,9 +602,29 @@ class TestBuildCustomLabels:
             "example.com/workload-name": "MyApp-py",
         }
 
-    def test_suffix_key_not_in_labels_logs_warning(self):
+    def test_suffix_key_not_in_labels_logs_warning(self, capsys):
         labels_json = '{"team": "platform"}'
         suffix_json = '["nonexistent-key", "team"]'
         result = client.build_custom_labels(labels_json, suffix_json, "go")
         assert result == {"team": "platform-go"}
         assert "nonexistent-key" not in result
+        captured = capsys.readouterr()
+        assert "nonexistent-key" in captured.out
+
+    def test_non_dict_labels_json_returns_empty(self):
+        result = client.build_custom_labels('["a", "b"]', "", "py")
+        assert result == {}
+
+    def test_non_string_values_labels_json_returns_empty(self):
+        result = client.build_custom_labels('{"team": 123}', "", "py")
+        assert result == {}
+
+    def test_non_list_suffix_json_ignored(self):
+        labels_json = '{"team": "platform"}'
+        result = client.build_custom_labels(labels_json, '{"key": "val"}', "py")
+        assert result == {"team": "platform"}
+
+    def test_non_string_suffix_list_ignored(self):
+        labels_json = '{"team": "platform"}'
+        result = client.build_custom_labels(labels_json, "[1, 2]", "py")
+        assert result == {"team": "platform"}

--- a/tests/unit/test_kubernetes_client.py
+++ b/tests/unit/test_kubernetes_client.py
@@ -537,3 +537,71 @@ class TestCreatePodManifest:
         )
 
         assert pod.spec.image_pull_secrets is None
+
+
+class TestBuildCustomLabels:
+    """Tests for build_custom_labels function."""
+
+    def test_empty_pod_labels_returns_empty(self):
+        result = client.build_custom_labels("", "", "py")
+        assert result == {}
+
+    def test_basic_labels_no_suffix(self):
+        labels_json = '{"team": "platform", "env": "prod"}'
+        result = client.build_custom_labels(labels_json, "", "py")
+        assert result == {"team": "platform", "env": "prod"}
+
+    def test_language_suffix_applied(self):
+        labels_json = '{"workload-name": "KubeCodeRun", "workload-type": "CodeInterpreter"}'
+        suffix_json = '["workload-name"]'
+        result = client.build_custom_labels(labels_json, suffix_json, "py")
+        assert result == {"workload-name": "KubeCodeRun-py", "workload-type": "CodeInterpreter"}
+
+    def test_language_suffix_preserves_casing(self):
+        labels_json = '{"name": "MyApp"}'
+        suffix_json = '["name"]'
+        result = client.build_custom_labels(labels_json, suffix_json, "js")
+        assert result["name"] == "MyApp-js"
+
+    def test_protected_prefix_app_kubernetes_blocked(self):
+        labels_json = '{"app.kubernetes.io/name": "evil", "safe-label": "ok"}'
+        result = client.build_custom_labels(labels_json, "", "py")
+        assert "app.kubernetes.io/name" not in result
+        assert result == {"safe-label": "ok"}
+
+    def test_protected_prefix_kubecoderun_blocked(self):
+        labels_json = '{"kubecoderun.io/language": "hax", "team": "good"}'
+        result = client.build_custom_labels(labels_json, "", "py")
+        assert "kubecoderun.io/language" not in result
+        assert result == {"team": "good"}
+
+    def test_invalid_labels_json_returns_empty(self):
+        result = client.build_custom_labels("not-json", "", "py")
+        assert result == {}
+
+    def test_invalid_suffix_json_still_returns_labels(self):
+        labels_json = '{"team": "platform"}'
+        result = client.build_custom_labels(labels_json, "not-json", "py")
+        assert result == {"team": "platform"}
+
+    def test_suffix_key_not_in_labels_ignored(self):
+        labels_json = '{"team": "platform"}'
+        suffix_json = '["missing-key"]'
+        result = client.build_custom_labels(labels_json, suffix_json, "py")
+        assert result == {"team": "platform"}
+
+    def test_real_world_multi_label_with_suffix(self):
+        labels_json = '{"example.com/workload-type": "CodeRunner", "example.com/workload-name": "MyApp"}'
+        suffix_json = '["example.com/workload-name"]'
+        result = client.build_custom_labels(labels_json, suffix_json, "py")
+        assert result == {
+            "example.com/workload-type": "CodeRunner",
+            "example.com/workload-name": "MyApp-py",
+        }
+
+    def test_suffix_key_not_in_labels_logs_warning(self):
+        labels_json = '{"team": "platform"}'
+        suffix_json = '["nonexistent-key", "team"]'
+        result = client.build_custom_labels(labels_json, suffix_json, "go")
+        assert result == {"team": "platform-go"}
+        assert "nonexistent-key" not in result


### PR DESCRIPTION
## Summary

Adds two new optional environment variables to attach extra Kubernetes labels
to all execution pods (pool and job), with the ability to automatically
append a per-language suffix to selected label values.

## New Configuration

| Variable | Default | Description |
|---|---|---|
| `K8S_POD_LABELS` | `""` | JSON-encoded dict of extra labels for all execution pods |
| `K8S_POD_LABEL_LANGUAGE_SUFFIX` | `""` | JSON-encoded list of label keys that get `-<lang>` appended |

**Example:**
```bash
K8S_POD_LABELS='{"example.com/workload-type":"CodeRunner","example.com/workload-name":"MyApp"}'
K8S_POD_LABEL_LANGUAGE_SUFFIX='["example.com/workload-name"]'
# → Python pod: example.com/workload-name=MyApp-py
# → JS pod:     example.com/workload-name=MyApp-js
```

Both variables are optional. Omitting them changes nothing.

## Behaviour

- Labels under `app.kubernetes.io/*` and `kubecoderun.io/*` are protected and silently dropped if provided
- Suffix keys that don't match any key in `K8S_POD_LABELS` emit a structured warning log without blocking startup
- Invalid JSON in either variable logs a warning and is ignored

## Files Changed

- __init__.py / kubernetes.py — new settings fields
- client.py — `build_custom_labels()` helper
- models.py — `PoolConfig` + `PodSpec` updated
- pool.py / job_executor.py — label merge at pod creation
- manager.py / main.py — wiring
- .env.example + CONFIGURATION.md — documentation
- test_kubernetes_client.py — 11 new unit tests

## Validation

- ✅ `ruff check` — no issues
- ✅ `ruff format --check` — no issues
- ✅ `ty check` — no issues
- ✅ `pytest tests/unit/` — 1343 passed
- ✅ `bandit` (high severity) — no issues