### PR TITLE
feat: add bash language support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,7 @@ POD_POOL_JS=2     # JavaScript
 # POD_POOL_R=0    # R (default: 0)
 # POD_POOL_F90=0  # Fortran (default: 0)
 # POD_POOL_D=0    # D (default: 0)
+# POD_POOL_BASH=0 # Bash (default: 0)
 
 # Pool optimization settings
 POD_POOL_PARALLEL_BATCH=5

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For a deep dive into the system design, components, and request flows, see [ARCH
 
 The API provides endpoints for code execution, file management, and session state control.
 
-- `POST /exec`: Execute code in one of the 12 supported languages.
+- `POST /exec`: Execute code in one of the 13 supported languages.
 - `POST /upload`: Upload files for processing.
 - `GET /download`: Retrieve generated files.
 

--- a/docker/bash.Dockerfile
+++ b/docker/bash.Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+# Bash execution environment with Docker Hardened Images.
+# Uses debian-base since there is no dedicated DHI shell image.
+
+ARG RUNNER_IMAGE=ghcr.io/aron-muon/kubecoderun-runner:latest
+FROM ${RUNNER_IMAGE} AS runner
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+
+################################
+# Final stage - runtime image
+################################
+FROM dhi.io/debian-base:trixie-debian13-dev AS final
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="KubeCodeRun Bash Environment" \
+      org.opencontainers.image.description="Secure execution environment for Bash scripts" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install runtime utilities a typical bash script reaches for.
+# bash, coreutils, grep, sed, gawk are the bare minimum for the
+# shell to be useful; findutils (find/xargs) and jq cover the
+# next-most-common patterns.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bash \
+    coreutils \
+    grep \
+    sed \
+    gawk \
+    findutils \
+    jq \
+    ca-certificates \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /mnt/data && chown 65532:65532 /mnt/data
+
+WORKDIR /mnt/data
+
+USER 65532
+
+# Copy runner binary for code execution
+COPY --from=runner /runner /usr/local/bin/runner
+
+ENTRYPOINT ["/usr/bin/env", "-i", \
+    "PATH=/usr/bin:/bin", \
+    "HOME=/tmp", \
+    "TMPDIR=/tmp", \
+    "LANGUAGE=bash"]
+CMD ["/usr/local/bin/runner"]

--- a/docker/runner/executor.go
+++ b/docker/runner/executor.go
@@ -54,6 +54,9 @@ var languages = map[string]LangSpec{
 
 	"d":     {File: "code.d", Args: []string{"sh", "-c", "ldc2 {file} -of=/tmp/code && /tmp/code"}},
 	"dlang": {File: "code.d", Args: []string{"sh", "-c", "ldc2 {file} -of=/tmp/code && /tmp/code"}},
+
+	"bash": {File: "code.sh", Args: []string{"bash", "{file}"}},
+	"sh":   {File: "code.sh", Args: []string{"sh", "{file}"}},
 }
 
 // ExecuteRequest is the JSON request body for POST /execute.

--- a/docker/runner/executor_test.go
+++ b/docker/runner/executor_test.go
@@ -10,6 +10,7 @@ func TestLanguageSpecsExist(t *testing.T) {
 		"py", "python", "js", "javascript", "ts", "typescript",
 		"go", "java", "c", "cpp", "php", "rs", "rust",
 		"r", "f90", "fortran", "d", "dlang",
+		"bash", "sh",
 	}
 	for _, lang := range expected {
 		if _, ok := languages[lang]; !ok {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -356,10 +356,11 @@ Each supported programming language has its own configuration for container imag
 - **R** (`r`): `r-base:latest`
 - **Fortran** (`f90`): `gcc:latest`
 - **D** (`d`): `dlang2/dmd-ubuntu:latest`
+- **Bash** (`bash`): `bash:latest`
 
 ### Custom Language Images
 
-You can override default images using environment variables. The format is `LANG_IMAGE_<CODE>` where `<CODE>` is the language code (py, js, ts, go, java, c, cpp, php, rs, r, f90, d):
+You can override default images using environment variables. The format is `LANG_IMAGE_<CODE>` where `<CODE>` is the language code (py, js, ts, go, java, c, cpp, php, rs, r, f90, d, bash):
 
 ```bash
 LANG_IMAGE_PY=python:3.12-slim

--- a/helm-deployments/kubecoderun/templates/configmap.yaml
+++ b/helm-deployments/kubecoderun/templates/configmap.yaml
@@ -74,6 +74,7 @@ data:
   POD_POOL_R: {{ .Values.execution.languages.r.poolSize | quote }}
   POD_POOL_F90: {{ .Values.execution.languages.fortran.poolSize | quote }}
   POD_POOL_D: {{ .Values.execution.languages.d.poolSize | quote }}
+  POD_POOL_BASH: {{ .Values.execution.languages.bash.poolSize | quote }}
 
   # Per-language images
   # Uses full image if specified, otherwise builds from registry-suffix:tag
@@ -106,6 +107,8 @@ data:
   LANG_IMAGE_F90: {{ .Values.execution.languages.fortran.image | default $defaultImage | quote }}
   {{- $defaultImage = printf "%s-%s:%s" $registry "d" $defaultTag }}
   LANG_IMAGE_D: {{ .Values.execution.languages.d.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "bash" $defaultTag }}
+  LANG_IMAGE_BASH: {{ .Values.execution.languages.bash.image | default $defaultImage | quote }}
 
   # Per-language resource limits (falls back to execution.resources defaults)
   {{- $defaultCpuLimit := .Values.execution.resources.limits.cpu }}
@@ -243,6 +246,17 @@ data:
   LANG_MEMORY_LIMIT_D: {{ $defaultMemoryLimit | quote }}
   LANG_CPU_REQUEST_D: {{ $defaultCpuRequest | quote }}
   LANG_MEMORY_REQUEST_D: {{ $defaultMemoryRequest | quote }}
+  {{- end }}
+  {{- with .Values.execution.languages.bash.resources }}
+  LANG_CPU_LIMIT_BASH: {{ .limits.cpu | default $defaultCpuLimit | quote }}
+  LANG_MEMORY_LIMIT_BASH: {{ .limits.memory | default $defaultMemoryLimit | quote }}
+  LANG_CPU_REQUEST_BASH: {{ .requests.cpu | default $defaultCpuRequest | quote }}
+  LANG_MEMORY_REQUEST_BASH: {{ .requests.memory | default $defaultMemoryRequest | quote }}
+  {{- else }}
+  LANG_CPU_LIMIT_BASH: {{ $defaultCpuLimit | quote }}
+  LANG_MEMORY_LIMIT_BASH: {{ $defaultMemoryLimit | quote }}
+  LANG_CPU_REQUEST_BASH: {{ $defaultCpuRequest | quote }}
+  LANG_MEMORY_REQUEST_BASH: {{ $defaultMemoryRequest | quote }}
   {{- end }}
 
   # Execution Limits

--- a/helm-deployments/kubecoderun/values.yaml
+++ b/helm-deployments/kubecoderun/values.yaml
@@ -286,6 +286,8 @@ execution:
       poolSize: 0
     d:
       poolSize: 0
+    bash:
+      poolSize: 0
 
   # Job settings (for languages with poolSize=0)
   jobs:

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -56,6 +56,7 @@ LANGUAGE_IMAGES=(
     "r.Dockerfile:r:"  # R is really slow to build
     "fortran.Dockerfile:fortran:"
     "d.Dockerfile:d:"
+    "bash.Dockerfile:bash:"
 )
 
 # Infrastructure images with custom contexts

--- a/scripts/test-images.sh
+++ b/scripts/test-images.sh
@@ -66,6 +66,7 @@ TEST_CODE[d]='import std.stdio;
 void main() {
     writeln("Hello, KubeCodeRun!");
 }'
+TEST_CODE[bash]='echo "Hello, KubeCodeRun!"'
 
 # Language display names
 declare -A LANG_NAMES
@@ -81,6 +82,7 @@ LANG_NAMES[rs]="Rust"
 LANG_NAMES[r]="R"
 LANG_NAMES[f90]="Fortran"
 LANG_NAMES[d]="D"
+LANG_NAMES[bash]="Bash"
 
 # Image names for each language
 declare -A LANG_IMAGE
@@ -96,6 +98,7 @@ LANG_IMAGE[rs]=rust
 LANG_IMAGE[r]=r
 LANG_IMAGE[f90]=fortran
 LANG_IMAGE[d]=d
+LANG_IMAGE[bash]=bash
 
 usage() {
     head -n 14 "$0" | tail -n 12 | sed 's/^# //'
@@ -307,6 +310,9 @@ test_language() {
         r)
             output=$(run_stdin_test "$full_image" Rscript "$code" /dev/stdin) || exit_code=$?
             ;;
+        bash)
+            output=$(run_stdin_test "$full_image" bash "$code") || exit_code=$?
+            ;;
 
         # TypeScript uses wrapper script
         ts)
@@ -393,7 +399,7 @@ main() {
     if [[ ${#SPECIFIC_LANGS[@]} -gt 0 ]]; then
         langs_to_test=("${SPECIFIC_LANGS[@]}")
     else
-        langs_to_test=(py js ts go java c cpp php rs r f90 d)
+        langs_to_test=(py js ts go java c cpp php rs r f90 d bash)
     fi
 
     local passed=0

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -253,6 +253,7 @@ class Settings(BaseSettings):
     pod_pool_r: int = Field(default=0, ge=0, le=50, description="R pool size")
     pod_pool_f90: int = Field(default=0, ge=0, le=50, description="Fortran pool size")
     pod_pool_d: int = Field(default=0, ge=0, le=50, description="D pool size")
+    pod_pool_bash: int = Field(default=0, ge=0, le=50, description="Bash pool size")
 
     # Pool Optimization Configuration
     pod_pool_parallel_batch: int = Field(
@@ -630,7 +631,7 @@ class Settings(BaseSettings):
         from ..services.kubernetes.models import PoolConfig
 
         configs = []
-        languages = ["py", "js", "ts", "go", "java", "c", "cpp", "php", "rs", "r", "f90", "d"]
+        languages = ["py", "js", "ts", "go", "java", "c", "cpp", "php", "rs", "r", "f90", "d", "bash"]
 
         pool_sizes = {
             "py": self.pod_pool_py,
@@ -645,6 +646,7 @@ class Settings(BaseSettings):
             "r": self.pod_pool_r,
             "f90": self.pod_pool_f90,
             "d": self.pod_pool_d,
+            "bash": self.pod_pool_bash,
         }
 
         for lang in languages:

--- a/src/config/languages.py
+++ b/src/config/languages.py
@@ -164,6 +164,17 @@ LANGUAGES: dict[str, LanguageConfig] = {
         timeout_multiplier=2.0,
         memory_multiplier=1.2,
     ),
+    "bash": LanguageConfig(
+        code="bash",
+        name="Bash",
+        image="bash:latest",
+        user_id=65532,
+        file_extension="sh",
+        execution_command="bash",
+        uses_stdin=True,
+        timeout_multiplier=1.0,
+        memory_multiplier=1.0,
+    ),
 }
 
 

--- a/tests/unit/test_languages.py
+++ b/tests/unit/test_languages.py
@@ -54,9 +54,9 @@ class TestLanguagesRegistry:
     """Tests for LANGUAGES registry."""
 
     def test_all_languages_present(self):
-        """Test all 12 languages are registered."""
-        expected_codes = ["py", "js", "ts", "go", "java", "c", "cpp", "php", "rs", "r", "f90", "d"]
-        assert len(LANGUAGES) == 12
+        """Test all 13 languages are registered."""
+        expected_codes = ["py", "js", "ts", "go", "java", "c", "cpp", "php", "rs", "r", "f90", "d", "bash"]
+        assert len(LANGUAGES) == 13
         for code in expected_codes:
             assert code in LANGUAGES
 
@@ -79,6 +79,15 @@ class TestLanguagesRegistry:
         compiled = ["go", "java", "c", "cpp", "rs", "f90", "d", "ts"]
         for code in compiled:
             assert LANGUAGES[code].uses_stdin is False
+
+    def test_bash_config(self):
+        """Test Bash configuration."""
+        bash = LANGUAGES["bash"]
+        assert bash.name == "Bash"
+        assert bash.file_extension == "sh"
+        assert bash.execution_command == "bash"
+        assert bash.uses_stdin is True
+        assert bash.user_id == 65532
 
 
 class TestGetLanguage:
@@ -109,7 +118,7 @@ class TestGetSupportedLanguages:
         """Test returns list of language codes."""
         languages = get_supported_languages()
         assert isinstance(languages, list)
-        assert len(languages) == 12
+        assert len(languages) == 13
 
     def test_contains_common_languages(self):
         """Test common languages are included."""


### PR DESCRIPTION
## Summary

Adds bash as a 13th supported language.

Fixes # (no existing issue — happy to file one if preferred)

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Why

`@librechat/agents` 3.1.74+ auto-expands `agent.tools: ['execute_code']` to `bash_tool` + `read_file` and stops registering a separate Python `execute_code` tool. Any KubeCodeRun deployment fronting a recent LibreChat receives `lang: "bash"` on /exec and returns 400 `Unsupported programming language: bash`. Adding bash to the language fleet restores parity with what LibreChat now emits, and is consistent with the existing "one language image per runtime" pattern.

### What changed

Split into five atomic commits for review:

| # | Commit | Purpose |
|---|---|---|
| 1 | `feat(config): add bash to language registry` | `LanguageConfig` entry, `pod_pool_bash` setting, `get_pool_configs()` wiring, unit tests for 13-language count + bash-specific assertions |
| 2 | `feat(runner): add bash and sh to executor language map` | `executor.go` `languages` map entries (bash uses `code.sh`, direct `bash {file}` exec; sh as alias), `TestLanguageSpecsExist` updated |
| 3 | `feat(docker): add bash image and register in build/test scripts` | New `docker/bash.Dockerfile` based on `dhi.io/debian-base:trixie-debian13-dev` (single stage; installs `bash coreutils grep sed gawk findutils jq ca-certificates`); added to `scripts/build-images.sh` LANGUAGE_IMAGES and `scripts/test-images.sh` smoke test fleet |
| 4 | `feat(helm): expose bash language in the chart` | `languages.bash` (poolSize 0 default → Jobs), `POD_POOL_BASH` / `LANG_IMAGE_BASH` / `LANG_*_BASH` env in configmap template, mirroring every other language's structure |
| 5 | `docs: list bash among the supported languages` | README count, CONFIGURATION.md supported-languages list + LANG_IMAGE_ code roster, `.env.example` POD_POOL hint block |

### Design notes

- **Base image**: `dhi.io/debian-base:trixie-debian13-dev` matches the pattern `r.Dockerfile` uses. Single-stage final image; no compilation needed.
- **Utilities included**: `bash`, `coreutils`, `grep`, `sed`, `gawk`, `findutils`, `jq`, `ca-certificates`. Skipped `curl`/`wget` to keep image surface smaller.
- **Default pool size**: 0. Bash workloads cold-start via Jobs rather than burning warm pods, matching every other low-volume language in the chart.
- **Alias**: `sh` registered as a thin alias in `executor.go` so requests sending `lang: "sh"` also resolve — costs nothing and mirrors the python/py and rust/rs pattern.

## How Has This Been Tested?

- [x] `uv run pytest tests/unit/` — 1430 passed (including the new bash test cases)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `helm lint helm-deployments/kubecoderun/` — clean
- [ ] Go runner tests (`go test ./docker/runner/...`) — not run locally (no Go toolchain on the dev box); the `TestLanguageSpecsExist` assertion update is mechanical and CI will catch any miss
- [ ] End-to-end image build + smoke test (`scripts/build-images.sh bash` → `scripts/test-images.sh -l bash`) — not run locally, depends on `dhi.io` registry auth; will validate in CI

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
