### PR TITLE
fix: LibreChat 0.8.5 compatibility, cross-user file-leak, JWT auth, all-runtimes bash image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,34 @@ API_KEY_CACHE_TTL=300
 # MASTER_API_KEY=your-secure-master-key  # Required for CLI key management
 RATE_LIMIT_ENABLED=true
 
+# Global auth toggle (default true). When false, user-facing endpoints
+# skip api-key auth — use only when running behind a trusted boundary
+# (mTLS sidecar, VPC ingress, CIDR allowlist). Admin endpoints still
+# require MASTER_API_KEY regardless.
+# AUTH_ENABLED=true
+
+# Trusted-network bypass (CIDR list, comma-separated). Requests whose
+# socket peer IP falls in one of these networks skip api-key auth.
+# Useful for in-cluster callers when AUTH_ENABLED can't be flipped
+# globally. Source IP is the TCP peer, NOT X-Forwarded-For — unspoofable.
+# AUTH_TRUSTED_NETWORKS=10.0.0.0/8,172.16.0.0/12
+
+# LibreChat CodeAPI JWT Authentication
+# --------------------------------------
+# LibreChat 0.8.5 (danny-avila/LibreChat#13028) mints short-lived signed
+# JWTs and sends them as `Authorization: Bearer <jwt>`. Enable this
+# verifier when LC is configured with CODEAPI_AUTH_PROVIDER=librechat-jwt
+# (or `both`). Env-var names mirror LC's signer side 1:1 — copy values
+# from LC's deployment.
+#
+# CODEAPI_JWT_ENABLED=false
+# CODEAPI_JWT_PUBLIC_KEY=                 # PEM, JWK JSON, or file path
+# CODEAPI_JWT_ALGORITHM=EdDSA             # EdDSA (default) or RS256
+# CODEAPI_JWT_ISSUER=librechat
+# CODEAPI_JWT_AUDIENCE=codeapi
+# CODEAPI_JWT_LEEWAY_SECONDS=10
+# CODEAPI_JWT_TRUST_TENANT_ID=false       # record JWT tenant_id on sessions
+
 # Redis Configuration
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/docker/bash.Dockerfile
+++ b/docker/bash.Dockerfile
@@ -1,8 +1,42 @@
 # syntax=docker/dockerfile:1
-# Bash execution environment with Docker Hardened Images.
-# Uses debian-base since there is no dedicated DHI shell image.
+# Bash execution environment with EVERY supported language baked in.
+#
+# LibreChat @librechat/agents >= 3.1.74 collapsed `execute_code` and all
+# per-language code-interpreter tools into a single `bash_tool` — the
+# client no longer sends `lang: py | js | go | ...` to `/exec`; every
+# request now arrives as `lang: bash`. To stay useful for those clients,
+# the bash sandbox has to contain every interpreter and compiler so the
+# model can `python3 -c "..."`, `node -e "..."`, `go run`, etc. from
+# inside the shell.
+#
+# The dedicated per-language images still ship and are still served by
+# `/exec` when a non-LC caller sends an explicit `lang: <code>`, so
+# direct-API integrations are unaffected.
+#
+# Languages baked in (all 13):
+#   bash, sh                         — apt: bash + coreutils + jq + grep + sed
+#   python (py) + python data stack  — apt: python3 + python-is-python3 + numpy/pandas/etc.
+#   javascript (js)                  — apt: nodejs
+#   typescript (ts)                  — npm: typescript globally
+#   go                               — apt: golang-go
+#   java                             — apt: default-jdk-headless
+#   c, cpp                           — apt: gcc, g++
+#   php                              — apt: php-cli
+#   rust (rs)                        — apt: rustc, cargo
+#   r                                — apt: r-base-core
+#   fortran (f90)                    — apt: gfortran
+#   d                                — apt: ldc (uses gcc for linking)
+#
+# Size: ~1.5-2 GB vs ~100 MB for the bash-only image. Trade made deliberately
+# so every LC bash_tool request stays inside the warm pod instead of
+# erroring out on a missing interpreter.
 
+# Global args — must be declared before any FROM so they can interpolate
+# into the FROM lines. They lose scope inside the stages and are re-
+# declared there as needed.
 ARG RUNNER_IMAGE=ghcr.io/aron-muon/kubecoderun-runner:latest
+ARG BASE_IMAGE=dhi.io/debian-base:trixie-debian13-dev
+
 FROM ${RUNNER_IMAGE} AS runner
 
 ARG BUILD_DATE
@@ -12,26 +46,36 @@ ARG VCS_REF
 ################################
 # Final stage - runtime image
 ################################
-FROM dhi.io/debian-base:trixie-debian13-dev AS final
+FROM ${BASE_IMAGE} AS final
 
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
 
-LABEL org.opencontainers.image.title="KubeCodeRun Bash Environment" \
-      org.opencontainers.image.description="Secure execution environment for Bash scripts" \
+LABEL org.opencontainers.image.title="KubeCodeRun Bash Environment (all languages)" \
+      org.opencontainers.image.description="LibreChat bash_tool sandbox — bash + every supported runtime (py, js, ts, go, java, c, cpp, php, rs, r, f90, d)" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install runtime utilities a typical bash script reaches for.
-# bash, coreutils, grep, sed, gawk are the bare minimum for the
-# shell to be useful; findutils (find/xargs) and jq cover the
-# next-most-common patterns.
+# Single RUN to keep the layer count low. Order: shell utilities first, then
+# the language families. `apt-get clean` + cache wipe at the end shaves
+# ~50 MB off the final layer.
+#
+# python-is-python3 makes `python` resolve to /usr/bin/python3, matching
+# the executor.go Args for the "py" language (which calls `python {file}`).
+#
+# python3-{numpy,pandas,matplotlib,openpyxl,pil} ship the data-analysis
+# stack LLMs typically reach for via `python3 -c` inside bash_tool. Apt
+# is preferred over pip here because (a) layered binary deps make the
+# wheels reliable across base updates, and (b) we don't need bleeding-edge
+# versions for inside-bash one-liners — the dedicated python image still
+# serves `lang: "py"` calls that need pip.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    # --- bash + script utilities ---
     bash \
     coreutils \
     grep \
@@ -40,9 +84,41 @@ RUN apt-get update && \
     findutils \
     jq \
     ca-certificates \
+    # --- python (interpreter + data-analysis stack) ---
+    python3 \
+    python3-pip \
+    python-is-python3 \
+    python3-numpy \
+    python3-pandas \
+    python3-matplotlib \
+    python3-openpyxl \
+    python3-pil \
+    # --- node.js (js + ts) ---
+    nodejs \
+    npm \
+    # --- go ---
+    golang-go \
+    # --- java ---
+    default-jdk-headless \
+    # --- c / c++ / linker (used by rust, fortran, d too) ---
+    gcc \
+    g++ \
+    # --- php ---
+    php-cli \
+    # --- rust ---
+    rustc \
+    cargo \
+    # --- r ---
+    r-base-core \
+    # --- fortran ---
+    gfortran \
+    # --- d (ldc compiler) ---
+    ldc \
+    && npm install -g typescript \
+    && npm cache clean --force \
     && apt-get autoremove -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* /root/.cache /tmp/* \
     && mkdir -p /mnt/data && chown 65532:65532 /mnt/data
 
 WORKDIR /mnt/data
@@ -52,9 +128,40 @@ USER 65532
 # Copy runner binary for code execution
 COPY --from=runner /runner /usr/local/bin/runner
 
+# Copy TypeScript runner script (used by executor.go for the "ts" language).
+# Path is relative to the build context (docker/), matching nodejs.Dockerfile.
+COPY scripts/ts-runner.js /opt/scripts/ts-runner.js
+
+# Sanitized environment via env -i.
+#
+# HOME=/tmp is critical: rustc/cargo, go, R, javac, ldc, npm all write
+# build artefacts / caches under $HOME. /mnt/data is the user-code
+# working dir and shouldn't be polluted with .cache directories.
+#
+# GOCACHE/GOPATH and CARGO_HOME/RUSTUP_HOME are pinned under /tmp so
+# multiple executions of go/rust on the same warm pod don't race over
+# implicit defaults rooted at $HOME.
+#
+# JAVA_TOOL_OPTIONS=-Duser.home=/tmp keeps javac/java from trying to
+# write to a non-existent home of the sandbox UID.
+#
+# PYTHON{UNBUFFERED,DONTWRITEBYTECODE} mirror the dedicated python image
+# so stdout/stderr from `python3 -c` inside bash behaves identically.
+#
+# LANGUAGE=bash signals the runner's executor.go to drive the bash spec
+# (i.e. write code to code.sh and exec `bash code.sh`). The model is
+# free to shell out to any other interpreter from there.
 ENTRYPOINT ["/usr/bin/env", "-i", \
-    "PATH=/usr/bin:/bin", \
+    "PATH=/usr/local/bin:/usr/bin:/bin", \
     "HOME=/tmp", \
     "TMPDIR=/tmp", \
+    "GOCACHE=/tmp/go-cache", \
+    "GOPATH=/tmp/go", \
+    "CARGO_HOME=/tmp/cargo", \
+    "RUSTUP_HOME=/tmp/rustup", \
+    "JAVA_TOOL_OPTIONS=-Duser.home=/tmp", \
+    "PYTHONUNBUFFERED=1", \
+    "PYTHONDONTWRITEBYTECODE=1", \
+    "MPLCONFIGDIR=/tmp/matplotlib", \
     "LANGUAGE=bash"]
 CMD ["/usr/local/bin/runner"]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,14 +117,32 @@ SSL_REDIRECT=true
 
 Manages API key authentication and security.
 
-| Variable             | Default        | Description                                      |
-| -------------------- | -------------- | ------------------------------------------------ |
-| `API_KEY`            | `test-api-key` | Primary API key (CHANGE IN PRODUCTION)           |
-| `API_KEYS`           | -              | Additional API keys (comma-separated)            |
-| `API_KEY_HEADER`     | `x-api-key`    | HTTP header name for API key                     |
-| `API_KEY_CACHE_TTL`  | `300`          | API key validation cache TTL (seconds)           |
-| `MASTER_API_KEY`     | -              | Master API key for admin operations (CLI, admin) |
-| `RATE_LIMIT_ENABLED` | `true`         | Enable per-key rate limiting for Redis keys      |
+| Variable                | Default        | Description                                                                                                                       |
+| ----------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `API_KEY`               | `test-api-key` | Primary API key (CHANGE IN PRODUCTION)                                                                                            |
+| `API_KEYS`              | -              | Additional API keys (comma-separated)                                                                                             |
+| `API_KEY_HEADER`        | `x-api-key`    | HTTP header name for API key                                                                                                      |
+| `API_KEY_CACHE_TTL`     | `300`          | API key validation cache TTL (seconds)                                                                                            |
+| `MASTER_API_KEY`        | -              | Master API key for admin operations (CLI, admin)                                                                                  |
+| `RATE_LIMIT_ENABLED`    | `true`         | Enable per-key rate limiting for Redis keys                                                                                       |
+| `AUTH_ENABLED`          | `true`         | Global auth toggle. Set false to skip api-key auth on user paths (admin still requires `MASTER_API_KEY`).                         |
+| `AUTH_TRUSTED_NETWORKS` | -              | Comma-separated CIDRs whose socket peer IP bypasses api-key auth (e.g. `10.0.0.0/8`). Unspoofable — uses TCP peer, not XFF.       |
+
+**Auth source priority** (highest first, checked per request):
+
+1. **CodeAPI JWT** (`Authorization: Bearer <jwt>`) — verified by the keys in
+   `CODEAPI_JWT_*`. See the next section.
+2. **`x-api-key` header** — preferred legacy path.
+3. **`Authorization: Bearer <token>` / `ApiKey <token>`** — when the Bearer
+   value is NOT shaped like a JWT.
+4. **`Authorization: Basic base64(KEY:)`** — supports LibreChat 0.8.5
+   `LIBRECHAT_CODE_BASEURL=https://KEY@host/v1` (axios derives the Basic
+   header from URL credentials).
+5. **JSON body `LIBRECHAT_CODE_API_KEY` / `api_key` / `apiKey`** — supports
+   `@librechat/agents` 3.1.74 (body-spread). Tried only for JSON POST/PUT/PATCH.
+
+A failed JWT does NOT fall back to api-key (downgrade-attack defence) — 401
+is returned immediately.
 
 **Security Notes:**
 
@@ -132,6 +150,36 @@ Manages API key authentication and security.
 - Use cryptographically secure random keys in production
 - Consider rotating API keys regularly
 - The `MASTER_API_KEY` is required for admin dashboard and CLI key management
+
+### CodeAPI JWT Authentication (LibreChat 0.8.5+)
+
+LibreChat 0.8.5 ([danny-avila/LibreChat#13028](https://github.com/danny-avila/LibreChat/pull/13028))
+mints short-lived signed JWTs and sends them as `Authorization: Bearer <jwt>`
+when `CODEAPI_AUTH_PROVIDER=librechat-jwt` or `both`. Enable the verifier here
+to accept those tokens. Env-var names mirror LC's signer side 1:1 — copy the
+matching values from the LC deployment.
+
+| Variable                       | Default     | Description                                                                                                                                                                                                                                                                                            |
+| ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CODEAPI_JWT_ENABLED`          | `false`     | Accept LibreChat-minted CodeAPI JWTs. Off by default so legacy api-key clients keep working unchanged.                                                                                                                                                                                                 |
+| `CODEAPI_JWT_PUBLIC_KEY`       | -           | Public key paired with LC's `CODEAPI_JWT_PRIVATE_KEY` / `CODEAPI_JWT_PRIVATE_JWK_JSON`. Accepts PEM (`-----BEGIN PUBLIC KEY-----`), raw JWK JSON (`{"kty":...}`), or an absolute file path.                                                                                                              |
+| `CODEAPI_JWT_ALGORITHM`        | `EdDSA`     | Must match LC's `CODEAPI_JWT_ALGORITHM` (`EdDSA` is the default; `RS256` is supported). Pinned at verify time — `alg` header is NEVER trusted (alg-confusion defence).                                                                                                                                  |
+| `CODEAPI_JWT_ISSUER`           | `librechat` | Expected `iss` claim. Must match LC's `CODEAPI_JWT_ISSUER`.                                                                                                                                                                                                                                            |
+| `CODEAPI_JWT_AUDIENCE`         | `codeapi`   | Expected `aud` claim. Must match LC's `CODEAPI_JWT_AUDIENCE`.                                                                                                                                                                                                                                          |
+| `CODEAPI_JWT_LEEWAY_SECONDS`   | `10`        | Clock-skew tolerance for `exp` / `nbf` validation.                                                                                                                                                                                                                                                     |
+| `CODEAPI_JWT_TRUST_TENANT_ID`  | `false`     | When true, the JWT's `tenant_id` claim is recorded on new sessions (`metadata.tenant_id`). KubeCodeRun does not enforce tenant-scoped ACLs today; observability-only.                                                                                                                                  |
+
+**Trust model when JWT is enabled:**
+
+- The JWT's `sub` claim is the authoritative user id. It OVERRIDES the
+  `User-Id` HTTP header and any `user_id` field in the request body. This
+  prevents an attacker holding a valid JWT for user-A from operating against
+  user-victim's sessions by lying about user_id in headers/body.
+- Operators rotate signing keys by restarting the process (the public key
+  is process-cached).
+- Missing/expired/wrong-signature/wrong-iss/wrong-aud tokens → 401.
+- `CODEAPI_JWT_ENABLED=true` without `CODEAPI_JWT_PUBLIC_KEY` → 500
+  (server misconfiguration; client did nothing wrong).
 
 ### Redis Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "minio>=7.2.20",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
+    "pyjwt[crypto]>=2.10.0",
     "python-dateutil>=2.9.0.post0",
     "python-dotenv>=1.2.1",
     "python-multipart>=0.0.21",

--- a/scripts/test-bash-megaimage.sh
+++ b/scripts/test-bash-megaimage.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Validate that every supported language's hello-world compiles and runs
+# inside the unified bash image.
+#
+# For each of the 13 supported languages we:
+#   1. Write the language's hello-world source into a temp dir.
+#   2. Run the exact compile-and-run command from docker/runner/executor.go
+#      (so we exercise the same code path the runner binary would, just
+#      without going through HTTP).
+#   3. Assert the stdout contains "Hello, World!".
+#
+# Exit non-zero if any language fails. Failures print the captured output
+# so the operator can see *why* (missing package, broken alias, etc.).
+
+set -u
+
+IMAGE="${IMAGE:-kubecoderun-bash-all:test}"
+PLATFORM="${PLATFORM:-linux/amd64}"
+
+# Each entry: name|source_filename|hello-world-program|argv-after-sh-c
+# argv is the SHELL command we run inside the container. Mirrors the
+# `Args` field of each LangSpec in docker/runner/executor.go. {file}
+# resolves to the absolute path of source_filename inside /work, and
+# {wd} resolves to /work.
+LANGUAGES=(
+    "bash|code.sh|echo 'Hello, World!'|bash {file}"
+    "python|code.py|print('Hello, World!')|python {file}"
+    "javascript|code.js|console.log('Hello, World!')|node {file}"
+    "typescript|code.ts|const m: string = 'Hello, World!'; console.log(m);|node /opt/scripts/ts-runner.js {file}"
+    "go|main.go|package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"Hello, World!\") }|go run {file}"
+    "java|Code.java|public class Code { public static void main(String[] a) { System.out.println(\"Hello, World!\"); } }|javac {file} && java -cp {wd} Code"
+    "c|code.c|#include <stdio.h>\nint main() { printf(\"Hello, World!\\\\n\"); return 0; }|gcc {file} -o /tmp/code && /tmp/code"
+    "cpp|code.cpp|#include <iostream>\nint main() { std::cout << \"Hello, World!\" << std::endl; return 0; }|g++ {file} -o /tmp/code && /tmp/code"
+    "php|code.php|<?php echo \"Hello, World!\\\\n\"; ?>|php {file}"
+    "rust|main.rs|fn main() { println!(\"Hello, World!\"); }|rustc {file} -o /tmp/main && /tmp/main"
+    "r|code.r|cat('Hello, World!\\\\n')|Rscript {file}"
+    "fortran|code.f90|program hello\n  print *, 'Hello, World!'\nend program hello|gfortran {file} -o /tmp/code && /tmp/code"
+    "d|code.d|import std.stdio; void main() { writeln(\"Hello, World!\"); }|ldc2 {file} -of=/tmp/code && /tmp/code"
+)
+
+EXPECTED="Hello, World!"
+PASS=0
+FAIL=0
+FAILED_LANGS=()
+
+# Persistent tmpdir per run so all artefacts are isolated and easy to inspect
+# on failure.
+TMPROOT="$(mktemp -d -t kubecoderun-bash-test.XXXXXX)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+echo "Image: $IMAGE  (platform $PLATFORM)"
+echo "Tmp:   $TMPROOT"
+echo
+
+# Right-pad printf for tidy columns.
+pad() { printf '%-12s' "$1"; }
+
+for entry in "${LANGUAGES[@]}"; do
+    IFS='|' read -r lang fname program shell_cmd <<<"$entry"
+    workdir="$TMPROOT/$lang"
+    mkdir -p "$workdir"
+
+    # `\n` and `\\` survive a round-trip via printf %b — keeps the heredoc
+    # readable in the LANGUAGES table above.
+    printf '%b\n' "$program" > "$workdir/$fname"
+
+    # Substitute the placeholders the runner uses: {file} → absolute path
+    # inside the container, {wd} → working dir.
+    cmd="${shell_cmd//\{file\}/"/work/$fname"}"
+    cmd="${cmd//\{wd\}/"/work"}"
+
+    # Compile & run inside the container. We mount /tmp as a tmpfs-on-tmpfs
+    # mount inside the container so compilers can write to /tmp without
+    # touching the host. (The image already has HOME=/tmp via ENTRYPOINT,
+    # but we override the entrypoint here to drive raw shell commands.)
+    output=$(docker run --rm \
+        --platform "$PLATFORM" \
+        --user 65532 \
+        --entrypoint /bin/sh \
+        -e HOME=/tmp \
+        -e GOCACHE=/tmp/go-cache \
+        -e GOPATH=/tmp/go \
+        -e CARGO_HOME=/tmp/cargo \
+        -e RUSTUP_HOME=/tmp/rustup \
+        -e JAVA_TOOL_OPTIONS=-Duser.home=/tmp \
+        -v "$workdir":/work \
+        "$IMAGE" \
+        -c "$cmd" 2>&1)
+    rc=$?
+
+    if [[ $rc -eq 0 && "$output" == *"$EXPECTED"* ]]; then
+        echo "✓ $(pad "$lang") ok"
+        PASS=$((PASS + 1))
+    else
+        echo "✗ $(pad "$lang") FAILED (rc=$rc)"
+        echo "  cmd:    $cmd"
+        echo "  output: ${output:0:600}"
+        echo
+        FAIL=$((FAIL + 1))
+        FAILED_LANGS+=("$lang")
+    fi
+done
+
+echo
+echo "─────────────────────────────────────────"
+echo "  Passed: $PASS / $((PASS + FAIL))"
+if [[ $FAIL -gt 0 ]]; then
+    echo "  Failed: ${FAILED_LANGS[*]}"
+    exit 1
+fi
+exit 0

--- a/src/api/exec.py
+++ b/src/api/exec.py
@@ -60,14 +60,27 @@ async def execute_code(
     api_key_hash = getattr(http_request.state, "api_key_hash", None)
     is_env_key = getattr(http_request.state, "is_env_key", False)
 
-    # LibreChat 0.8.5 (@librechat/agents >= 3.1.74) does not put user_id in
-    # the request body; it sends an `User-Id` header on every code-interpreter
-    # call (api/server/services/Files/Code/crud.js). Fall back to the header
-    # when the body field is missing so cross-user session isolation
-    # (orchestrator._get_or_create_session) has a user_id to match against.
-    # Without this fallback, every LC request would fall through to "create
-    # new session" and same-user file continuity would break.
-    if not request.user_id:
+    # Resolve user_id from the most-trustworthy source available, in order:
+    #
+    #   1. JWT.sub (request.state.user_id) — set by SecurityMiddleware
+    #      after verifying a CodeAPI JWT signed by LibreChat. This is
+    #      cryptographically authenticated and OVERRIDES whatever the body
+    #      or User-Id header says. Without this override, an attacker
+    #      holding a valid JWT for user-A could still pass user_id=B in
+    #      the body and operate against user-B's sessions.
+    #   2. ExecRequest.user_id (request body) — direct-API integration.
+    #   3. User-Id / X-User-Id HTTP header — LibreChat 0.8.5 sends this on
+    #      every code-interpreter call (api/server/services/Files/Code/
+    #      crud.js). Unsigned; only trusted in the absence of (1)/(2).
+    #
+    # Without this resolution chain, every LC request reaches the
+    # orchestrator with request.user_id=None and the cross-user session-
+    # isolation guard forces a fresh session every time, breaking same-
+    # user file continuity.
+    jwt_user_id = getattr(http_request.state, "user_id", None)
+    if jwt_user_id:
+        request.user_id = jwt_user_id
+    elif not request.user_id:
         header_user_id = http_request.headers.get("user-id") or http_request.headers.get("x-user-id")
         if header_user_id:
             request.user_id = header_user_id

--- a/src/api/exec.py
+++ b/src/api/exec.py
@@ -60,6 +60,18 @@ async def execute_code(
     api_key_hash = getattr(http_request.state, "api_key_hash", None)
     is_env_key = getattr(http_request.state, "is_env_key", False)
 
+    # LibreChat 0.8.5 (@librechat/agents >= 3.1.74) does not put user_id in
+    # the request body; it sends an `User-Id` header on every code-interpreter
+    # call (api/server/services/Files/Code/crud.js). Fall back to the header
+    # when the body field is missing so cross-user session isolation
+    # (orchestrator._get_or_create_session) has a user_id to match against.
+    # Without this fallback, every LC request would fall through to "create
+    # new session" and same-user file continuity would break.
+    if not request.user_id:
+        header_user_id = http_request.headers.get("user-id") or http_request.headers.get("x-user-id")
+        if header_user_id:
+            request.user_id = header_user_id
+
     logger.info(
         "Code execution request",
         request_id=request_id,

--- a/src/api/files.py
+++ b/src/api/files.py
@@ -190,10 +190,13 @@ async def upload_file(
             entity_id=entity_id,
         )
 
-        # Return LibreChat-compatible response
-        # Note: Production API returns different format with fileId instead of id
+        # Return LibreChat-compatible response.
+        # `storage_session_id` is the field LC 0.8.5 reads
+        # (api/server/services/Files/Code/crud.js); `session_id` is dual-
+        # emitted for back-compat with older clients.
         return {
             "message": "success",
+            "storage_session_id": session_id,
             "session_id": session_id,
             "files": [{"filename": file["name"], "fileId": file["id"]} for file in uploaded_files],
         }
@@ -205,6 +208,147 @@ async def upload_file(
         raise HTTPException(status_code=500, detail="Failed to upload files")
 
 
+@router.post("/upload/batch")
+async def upload_files_batch(
+    file: list[UploadFile] | None = File(None),
+    files: list[UploadFile] | None = File(None),
+    entity_id: str | None = Form(None),
+    kind: str | None = Form(None),
+    id: str | None = Form(None),
+    version: str | None = Form(None),
+    read_only: str | None = Form(None),
+    user_id_header: str | None = Header(None, alias="User-Id"),
+    x_user_id_header: str | None = Header(None, alias="X-User-Id"),
+    file_service: FileServiceDep = None,
+    session_service: SessionServiceDep = None,
+):
+    """Batch upload endpoint - LibreChat 0.8.5 compatible.
+
+    Used by ``@librechat/agents`` for skill priming (uploading a bundle of
+    files in a single request) — see api/server/services/Files/Code/crud.js
+    ``batchUploadCodeEnvFiles``. The single-file ``/upload`` works for
+    one-at-a-time uploads; this endpoint accepts a multi-file batch and
+    returns per-file ``succeeded`` / ``failed`` counts.
+
+    Form fields:
+
+      - ``file`` (or ``files``): one or more file parts (LC uses ``file``).
+      - ``entity_id``: optional, mirrors /upload.
+      - ``kind``: ``skill`` | ``agent`` | ``user``. LC sends this on every
+        batch upload. Treated as a hint; passed back in the response
+        envelope but not used for ACL today.
+      - ``id``: resource id (skillId / agentId / userId).
+      - ``version``: only meaningful with ``kind=skill``.
+      - ``read_only``: ``true`` marks every file as infrastructure (skill
+        bundle). Accepted but not yet enforced — placeholder for future
+        sandbox-side write-protection.
+
+    Returns ``{ message, storage_session_id, session_id, files: [...],
+    succeeded, failed }``.
+    """
+    request_user_id = user_id_header or x_user_id_header
+    upload_files: list[UploadFile] = file or files or []
+
+    if not upload_files:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Request validation failed",
+                "error_type": "validation",
+                "details": [{"field": "body -> file", "message": "Field required", "code": "missing"}],
+            },
+        )
+
+    if len(upload_files) > settings.max_files_per_session:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Too many files in batch. Maximum {settings.max_files_per_session} files allowed",
+        )
+
+    # Resolve session (same-user reuse, mirrors /upload).
+    session_id = None
+    if entity_id and request_user_id:
+        try:
+            existing = await session_service.list_sessions_by_entity(entity_id, limit=10)
+            for candidate in existing:
+                if getattr(candidate.status, "value", str(candidate.status)) != "active":
+                    continue
+                candidate_user = (candidate.metadata or {}).get("user_id")
+                if candidate_user and candidate_user == request_user_id:
+                    session_id = candidate.session_id
+                    break
+        except Exception as e:
+            logger.warning(
+                "Failed to look up batch upload session by entity_id",
+                entity_id=entity_id,
+                error=str(e),
+            )
+
+    if not session_id:
+        session_metadata: dict = {}
+        if entity_id:
+            session_metadata["entity_id"] = entity_id
+        if request_user_id:
+            session_metadata["user_id"] = request_user_id
+        if kind:
+            session_metadata["kind"] = kind
+        if id:
+            session_metadata["resource_id"] = id
+        session = await session_service.create_session(SessionCreate(metadata=session_metadata))
+        session_id = session.session_id
+
+    results: list[dict] = []
+    succeeded = 0
+    failed = 0
+
+    for upload in upload_files:
+        try:
+            if upload.size and upload.size > settings.max_file_size_mb * 1024 * 1024:
+                raise ValueError(f"File {upload.filename} exceeds maximum size of {settings.max_file_size_mb}MB")
+
+            content = await upload.read()
+            sanitized_name = OutputProcessor.sanitize_filename(upload.filename or "file")
+            file_id = await file_service.store_uploaded_file(
+                session_id=session_id,
+                filename=sanitized_name,
+                content=content,
+                content_type=upload.content_type,
+            )
+            results.append(
+                {
+                    "status": "success",
+                    "fileId": file_id,
+                    "filename": sanitized_name,
+                }
+            )
+            succeeded += 1
+        except Exception as e:  # noqa: BLE001 — per-file isolation for batch
+            logger.warning(
+                "Batch upload file failed",
+                filename=upload.filename,
+                error=str(e),
+            )
+            results.append(
+                {
+                    "status": "error",
+                    "filename": upload.filename,
+                    "error": str(e),
+                }
+            )
+            failed += 1
+
+    message = "success" if succeeded > 0 else "error"
+
+    return {
+        "message": message,
+        "storage_session_id": session_id,
+        "session_id": session_id,
+        "files": results,
+        "succeeded": succeeded,
+        "failed": failed,
+    }
+
+
 @router.get("/files/{session_id}")
 async def list_files(
     session_id: str,
@@ -212,10 +356,29 @@ async def list_files(
         None,
         description="Detail level: 'simple' for basic info, otherwise full details",
     ),
+    kind: str | None = Query(
+        None,
+        description="Resource kind filter for LibreChat scoped listing: 'skill', 'agent', or 'user'",
+    ),
+    id: str | None = Query(
+        None,
+        description="Resource id for scoped listing (LibreChat agents lib fetchSessionFiles)",
+    ),
+    version: int | None = Query(
+        None,
+        description="Resource version (only meaningful when kind=skill)",
+    ),
     file_service: FileServiceDep = None,
     session_service: SessionServiceDep = None,
 ):
-    """List all files in a session with optional detail parameter - LibreChat compatible."""
+    """List all files in a session with optional detail parameter - LibreChat compatible.
+
+    ``kind``/``id``/``version`` query params are accepted for LibreChat 0.8.5
+    compatibility (``@librechat/agents`` fetchSessionFiles). They are currently
+    pass-through metadata: we do not filter by them server-side because our
+    file storage does not yet carry the discriminator. Accepting them avoids
+    422 validation errors from LC clients that send the params unconditionally.
+    """
     try:
         files = await file_service.list_files(session_id)
 
@@ -296,6 +459,9 @@ async def list_files(
                     {
                         "name": sanitized_name,
                         "id": file_info.file_id,
+                        # `storage_session_id` is the field LC 0.8.5 reads;
+                        # `session_id` is dual-emitted for back-compat.
+                        "storage_session_id": session_id,
                         "session_id": session_id,
                         "content": None,  # Not returned in list
                         "size": file_info.size,

--- a/src/api/files.py
+++ b/src/api/files.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 
 # Third-party imports
 import structlog
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.responses import Response, StreamingResponse
 from unidecode import unidecode
 
@@ -48,6 +48,8 @@ async def upload_file(
     file: UploadFile | None = File(None),
     files: list[UploadFile] | None = File(None),
     entity_id: str | None = Form(None),
+    user_id_header: str | None = Header(None, alias="User-Id"),
+    x_user_id_header: str | None = Header(None, alias="X-User-Id"),
     file_service: FileServiceDep = None,
     session_service: SessionServiceDep = None,
 ):
@@ -55,7 +57,15 @@ async def upload_file(
 
     Accepts files in either 'file' (singular) or 'files' (plural) field names.
     LibreChat uses 'file' while our tests use 'files'.
+
+    LibreChat 0.8.5 sends ``User-Id: <user-id>`` on every upload
+    (api/server/services/Files/Code/crud.js). We persist that on
+    session.metadata.user_id so cross-user session-isolation checks
+    (orchestrator._get_or_create_session) can prove ownership later.
     """
+    # Resolve user id from headers (LibreChat convention is `User-Id`; we
+    # also accept `X-User-Id` for clients that prefer the X- convention).
+    request_user_id = user_id_header or x_user_id_header
     try:
         # Handle both singular and plural field names
         upload_files = []
@@ -103,19 +113,28 @@ async def upload_file(
         # When entity_id is provided, reuse the existing session for that
         # entity so that multiple file uploads land in the same session
         # (fixes issue #34 where separate uploads created isolated sessions).
+        #
+        # SECURITY: same-user gating mirrors orchestrator._get_or_create_session.
+        # Without this, two different users uploading files for the same
+        # shared agent would collapse onto a single session and see each
+        # other's uploads. Only reuse when the existing session's
+        # metadata.user_id matches the current request's User-Id header.
         session_id = None
-        if entity_id:
+        if entity_id and request_user_id:
             try:
-                existing = await session_service.list_sessions_by_entity(entity_id, limit=1)
-                if existing:
-                    candidate = existing[0]
-                    if getattr(candidate.status, "value", str(candidate.status)) == "active":
+                existing = await session_service.list_sessions_by_entity(entity_id, limit=10)
+                for candidate in existing:
+                    if getattr(candidate.status, "value", str(candidate.status)) != "active":
+                        continue
+                    candidate_user = (candidate.metadata or {}).get("user_id")
+                    if candidate_user and candidate_user == request_user_id:
                         session_id = candidate.session_id
                         logger.info(
-                            "Reusing existing session for entity",
+                            "Reusing existing session for entity (same user)",
                             session_id=session_id,
                             entity_id=entity_id,
                         )
+                        break
             except Exception as e:
                 logger.warning(
                     "Failed to look up session by entity_id",
@@ -124,9 +143,11 @@ async def upload_file(
                 )
 
         if not session_id:
-            session_metadata = {}
+            session_metadata: dict = {}
             if entity_id:
                 session_metadata["entity_id"] = entity_id
+            if request_user_id:
+                session_metadata["user_id"] = request_user_id
             session = await session_service.create_session(SessionCreate(metadata=session_metadata))
             session_id = session.session_id
 

--- a/src/api/files.py
+++ b/src/api/files.py
@@ -45,6 +45,7 @@ def _build_content_disposition(filename: str | None, fallback_identifier: str) -
 
 @router.post("/upload")
 async def upload_file(
+    request: Request,
     file: UploadFile | None = File(None),
     files: list[UploadFile] | None = File(None),
     entity_id: str | None = Form(None),
@@ -58,14 +59,18 @@ async def upload_file(
     Accepts files in either 'file' (singular) or 'files' (plural) field names.
     LibreChat uses 'file' while our tests use 'files'.
 
-    LibreChat 0.8.5 sends ``User-Id: <user-id>`` on every upload
-    (api/server/services/Files/Code/crud.js). We persist that on
-    session.metadata.user_id so cross-user session-isolation checks
-    (orchestrator._get_or_create_session) can prove ownership later.
+    user_id resolution (most-trustworthy first):
+      1. JWT.sub via request.state.user_id (cryptographically authenticated
+         by SecurityMiddleware when codeapi_jwt_enabled).
+      2. ``User-Id`` HTTP header (LibreChat 0.8.5 convention).
+      3. ``X-User-Id`` HTTP header (X- naming convention).
+
+    The resolved value is persisted on session.metadata.user_id so the
+    cross-user session-isolation check (orchestrator._get_or_create_session)
+    can prove ownership at exec time.
     """
-    # Resolve user id from headers (LibreChat convention is `User-Id`; we
-    # also accept `X-User-Id` for clients that prefer the X- convention).
-    request_user_id = user_id_header or x_user_id_header
+    jwt_user_id = getattr(request.state, "user_id", None) if request else None
+    request_user_id = jwt_user_id or user_id_header or x_user_id_header
     try:
         # Handle both singular and plural field names
         upload_files = []
@@ -210,6 +215,7 @@ async def upload_file(
 
 @router.post("/upload/batch")
 async def upload_files_batch(
+    request: Request,
     file: list[UploadFile] | None = File(None),
     files: list[UploadFile] | None = File(None),
     entity_id: str | None = Form(None),
@@ -245,8 +251,12 @@ async def upload_files_batch(
 
     Returns ``{ message, storage_session_id, session_id, files: [...],
     succeeded, failed }``.
+
+    user_id resolution mirrors ``/upload`` — JWT.sub via
+    ``request.state.user_id`` wins over the User-Id / X-User-Id headers.
     """
-    request_user_id = user_id_header or x_user_id_header
+    jwt_user_id = getattr(request.state, "user_id", None) if request else None
+    request_user_id = jwt_user_id or user_id_header or x_user_id_header
     upload_files: list[UploadFile] = file or files or []
 
     if not upload_files:

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -101,6 +101,59 @@ class Settings(BaseSettings):
         ),
     )
 
+    # CodeAPI JWT — LibreChat 0.8.5 (danny-avila/LibreChat#13028) mints
+    # short-lived signed JWTs and sends them as `Authorization: Bearer <jwt>`.
+    # When this verifier is enabled we accept those tokens in addition to the
+    # legacy API-key / Basic-auth paths. Env-var names mirror LC's signer side
+    # (CODEAPI_JWT_*) so operator docs are 1:1.
+    codeapi_jwt_enabled: bool = Field(
+        default=False,
+        description=(
+            "Accept LibreChat-minted CodeAPI JWTs in Authorization: Bearer. "
+            "Required when LibreChat is configured with "
+            "CODEAPI_AUTH_PROVIDER=librechat-jwt|both. Off by default so legacy "
+            "API-key clients continue to work unchanged."
+        ),
+    )
+    codeapi_jwt_public_key: str | None = Field(
+        default=None,
+        description=(
+            "Public key for verifying CodeAPI JWTs. Accepts PEM (begins with "
+            "'-----BEGIN PUBLIC KEY-----'), raw JWK JSON ('{\"kty\":...}'), or "
+            "an absolute file path. Pairs with LibreChat's "
+            "CODEAPI_JWT_PRIVATE_KEY / CODEAPI_JWT_PRIVATE_JWK_JSON."
+        ),
+    )
+    codeapi_jwt_algorithm: Literal["EdDSA", "RS256"] = Field(
+        default="EdDSA",
+        description="JWT signing algorithm. Must match LC's CODEAPI_JWT_ALGORITHM.",
+    )
+    codeapi_jwt_issuer: str = Field(
+        default="librechat",
+        description="Expected `iss` claim. Must match LC's CODEAPI_JWT_ISSUER.",
+    )
+    codeapi_jwt_audience: str = Field(
+        default="codeapi",
+        description="Expected `aud` claim. Must match LC's CODEAPI_JWT_AUDIENCE.",
+    )
+    codeapi_jwt_leeway_seconds: int = Field(
+        default=10,
+        ge=0,
+        le=60,
+        description=(
+            "Clock-skew tolerance for exp/nbf validation. LC mints tokens "
+            "with nbf=iat and a 300s TTL by default, so small skew is normal."
+        ),
+    )
+    codeapi_jwt_trust_tenant_id: bool = Field(
+        default=False,
+        description=(
+            "When true, the JWT's `tenant_id` claim is recorded on new "
+            "sessions (metadata.tenant_id). KubeCodeRun does not enforce "
+            "tenant-scoped ACLs today; this is observability-only."
+        ),
+    )
+
     # Redis Configuration
     redis_host: str = Field(default="localhost")
     redis_port: int = Field(default=6379, ge=1, le=65535)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -90,6 +90,16 @@ class Settings(BaseSettings):
         default="",
         description="Comma-separated CIDRs that bypass API key auth (e.g. '10.0.0.0/8,172.16.0.0/12')",
     )
+    auth_enabled: bool = Field(
+        default=True,
+        description=(
+            "Require an API key (header or Basic auth) on user endpoints. "
+            "Set false when running behind a trusted network boundary where "
+            "another layer (mTLS, VPC, sidecar) already authenticates callers. "
+            "Admin endpoints (/api/v1/admin) ALWAYS require MASTER_API_KEY "
+            "regardless of this setting."
+        ),
+    )
 
     # Redis Configuration
     redis_host: str = Field(default="localhost")

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,5 +1,7 @@
 """Authentication middleware for API key validation."""
 
+import base64
+import binascii
 import ipaddress
 import json
 import time
@@ -151,19 +153,32 @@ class AuthenticationMiddleware:
         scope["state"]["api_key"] = api_key
 
     def _extract_api_key(self, request: Request) -> str | None:
-        """Extract API key from request headers."""
-        # Check x-api-key header first
+        """Extract API key from request headers.
+
+        Order: ``x-api-key`` → ``Authorization: Bearer/ApiKey/Basic``.
+        See ``SecurityMiddleware._extract_api_key`` for the rationale on
+        Basic support (LibreChat 0.8.5 / ``@librechat/agents`` ≥ 3.1.74
+        compatibility).
+        """
         api_key = request.headers.get("x-api-key")
         if api_key:
             return api_key
 
-        # Check Authorization header
-        auth_header = request.headers.get("authorization")
-        if auth_header:
-            if auth_header.startswith("Bearer "):
-                return auth_header[7:]
-            elif auth_header.startswith("ApiKey "):
-                return auth_header[7:]
+        auth_header = request.headers.get("authorization") or ""
+        if not auth_header:
+            return None
+
+        scheme, _, value = auth_header.partition(" ")
+        scheme_lower = scheme.lower()
+        if scheme_lower in ("bearer", "apikey") and value:
+            return value
+        if scheme_lower == "basic" and value:
+            try:
+                decoded = base64.b64decode(value, validate=True).decode("utf-8", errors="replace")
+            except (binascii.Error, ValueError):
+                return None
+            user, _, password = decoded.partition(":")
+            return user or password or None
 
         return None
 

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -1,6 +1,8 @@
 """Consolidated security middleware for the Code Interpreter API."""
 
 # Standard library imports
+import base64
+import binascii
 import ipaddress
 import json
 import time
@@ -100,7 +102,7 @@ class SecurityMiddleware:
             await self._validate_request(request)
 
             # Handle authentication (skip for excluded paths and OPTIONS)
-            if not self._should_skip_auth(request):
+            if not self._should_skip_auth(request, scope):
                 # Try header-based extraction first
                 api_key = self._extract_api_key(request)
 
@@ -156,22 +158,63 @@ class SecurityMiddleware:
             if not any(allowed in content_type for allowed in allowed_types):
                 raise HTTPException(status_code=415, detail=f"Unsupported content type: {content_type}")
 
-    def _should_skip_auth(self, request: Request) -> bool:
-        """Check if authentication should be skipped."""
+    def _should_skip_auth(self, request: Request, scope: dict) -> bool:
+        """Check if authentication should be skipped.
+
+        Returns True for:
+          1. Excluded paths (/health, /docs, /redoc, /openapi.json) or OPTIONS.
+          2. Admin paths — middleware skips; the admin endpoints enforce
+             MASTER_API_KEY via their own dependency.
+          3. Requests from a configured trusted network CIDR
+             (AUTH_TRUSTED_NETWORKS — VPC-scoped bypass).
+          4. ``settings.auth_enabled == False`` on non-admin paths
+             (operator-controlled global bypass for trusted-boundary
+             deployments). Admin paths still require MASTER_API_KEY.
+
+        For trusted-network and disabled-auth bypasses we seed scope state
+        with anonymous markers so downstream code that reads
+        ``request.state.api_key_hash`` / ``is_env_key`` does not raise.
+        """
         path = request.url.path
-        if (
-            path in self.excluded_paths
-            or path.startswith("/api/v1/admin")
-            or path.startswith("/admin-dashboard")
-            or request.method == "OPTIONS"
-        ):
+        is_admin_path = path.startswith("/api/v1/admin") or path.startswith("/admin-dashboard")
+
+        if path in self.excluded_paths or request.method == "OPTIONS":
             return True
 
-        # Bypass auth for requests from trusted networks (e.g. in-cluster callers)
+        # Admin paths bypass middleware auth; their own dependencies require
+        # MASTER_API_KEY, so the bypass is safe and intentional.
+        if is_admin_path:
+            return True
+
+        # Trusted-network bypass — only applies to user-facing paths.
         if self._trusted_networks and self._is_trusted_network(request):
+            self._grant_anonymous_access(scope)
+            return True
+
+        # Operator-controlled bypass for trusted-boundary deployments
+        # (e.g. mTLS sidecar, VPC ingress). Never applies to admin paths.
+        if not settings.auth_enabled:
+            self._grant_anonymous_access(scope)
             return True
 
         return False
+
+    @staticmethod
+    def _grant_anonymous_access(scope: dict) -> None:
+        """Seed scope state for requests that bypassed authentication.
+
+        Downstream code (exec endpoint, orchestrator metrics) reads
+        ``request.state.api_key_hash`` and ``request.state.is_env_key``.
+        Seeding ``"anonymous"`` keeps dashboards / log lines readable and
+        avoids ``AttributeError`` when callers do ``getattr(..., None)``
+        with type-narrowed code paths.
+        """
+        scope_state = scope.get("state") or {}
+        scope_state.setdefault("authenticated", True)
+        scope_state.setdefault("api_key", "")
+        scope_state.setdefault("api_key_hash", "anonymous")
+        scope_state.setdefault("is_env_key", False)
+        scope["state"] = scope_state
 
     @staticmethod
     def _parse_trusted_networks(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
@@ -278,19 +321,47 @@ class SecurityMiddleware:
             await auth_service.record_usage(result.key_hash, is_env_key=result.is_env_key)
 
     def _extract_api_key(self, request: Request) -> str | None:
-        """Extract API key from request headers."""
-        # Check x-api-key header first
+        """Extract API key from request headers.
+
+        Sources checked, in order:
+        1. ``x-api-key`` header — preferred when present (reverse-proxy injection,
+           older LibreChat versions).
+        2. ``Authorization: Bearer <token>`` / ``Authorization: ApiKey <token>``.
+        3. ``Authorization: Basic <base64(user:pass)>`` — LibreChat 0.8.5
+           (``@librechat/agents`` ≥ 3.1.74) dropped both the ``x-api-key``
+           header and the body-spread ``LIBRECHAT_CODE_API_KEY`` field. The
+           only way the legacy ``LIBRECHAT_CODE_BASEURL=https://KEY@host/v1``
+           pattern still reaches us is via the Basic header that ``axios``
+           auto-derives from URL credentials. We return the user half (the
+           legacy convention LC uses) and fall back to the password half so
+           ``user:KEY`` deployments still work.
+
+        Returns the first key found, or None.
+        """
+        # 1. x-api-key wins when present.
         api_key = request.headers.get("x-api-key")
         if api_key:
             return api_key
 
-        # Check Authorization header
-        auth_header = request.headers.get("authorization")
-        if auth_header:
-            if auth_header.startswith("Bearer "):
-                return auth_header[7:]
-            elif auth_header.startswith("ApiKey "):
-                return auth_header[7:]
+        # 2/3. Authorization header.
+        auth_header = request.headers.get("authorization") or ""
+        if not auth_header:
+            return None
+
+        scheme, _, value = auth_header.partition(" ")
+        scheme_lower = scheme.lower()
+        if scheme_lower in ("bearer", "apikey") and value:
+            return value
+        if scheme_lower == "basic" and value:
+            try:
+                decoded = base64.b64decode(value, validate=True).decode("utf-8", errors="replace")
+            except (binascii.Error, ValueError):
+                return None
+            user, _, password = decoded.partition(":")
+            # LibreChat's URL-embedded credential pattern puts the key in the
+            # user half (no password); generic ``user:KEY`` deployments use
+            # the password half. Prefer user, fall back to password.
+            return user or password or None
 
         return None
 

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -121,9 +121,7 @@ class SecurityMiddleware:
                     # If no key in headers, try JSON body extraction
                     # for POST/PUT/PATCH (LC ≤ 3.1.74 spread the key
                     # into the body as LIBRECHAT_CODE_API_KEY).
-                    content_type = (
-                        request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
-                    )
+                    content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
                     if (
                         api_key is None
                         and request.method in ("POST", "PUT", "PATCH")

--- a/src/middleware/security.py
+++ b/src/middleware/security.py
@@ -3,6 +3,7 @@
 # Standard library imports
 import base64
 import binascii
+import hashlib
 import ipaddress
 import json
 import time
@@ -103,20 +104,35 @@ class SecurityMiddleware:
 
             # Handle authentication (skip for excluded paths and OPTIONS)
             if not self._should_skip_auth(request, scope):
-                # Try header-based extraction first
-                api_key = self._extract_api_key(request)
+                # CodeAPI JWT path (LibreChat 0.8.5+).
+                # If a Bearer token is present AND it structurally looks
+                # like a JWT AND JWT verification is enabled, that takes
+                # precedence over the API-key path. On JWT validation
+                # failure we 401 immediately rather than falling back to
+                # API-key extraction — falling back would let an attacker
+                # downgrade by submitting a deliberately-bad JWT.
+                jwt_token = self._extract_bearer_jwt(request)
+                if jwt_token is not None:
+                    await self._authenticate_jwt(jwt_token, scope)
+                else:
+                    # Legacy API-key path.
+                    api_key = self._extract_api_key(request)
 
-                # If no key in headers, try JSON body extraction for POST/PUT/PATCH
-                content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
-                if (
-                    api_key is None
-                    and request.method in ("POST", "PUT", "PATCH")
-                    and content_type == "application/json"
-                ):
-                    body_bytes, receive = await self._buffer_body(receive)
-                    api_key = self._extract_api_key_from_body(body_bytes)
+                    # If no key in headers, try JSON body extraction
+                    # for POST/PUT/PATCH (LC ≤ 3.1.74 spread the key
+                    # into the body as LIBRECHAT_CODE_API_KEY).
+                    content_type = (
+                        request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                    )
+                    if (
+                        api_key is None
+                        and request.method in ("POST", "PUT", "PATCH")
+                        and content_type == "application/json"
+                    ):
+                        body_bytes, receive = await self._buffer_body(receive)
+                        api_key = self._extract_api_key_from_body(body_bytes)
 
-                await self._authenticate_request(request, scope, api_key=api_key)
+                    await self._authenticate_request(request, scope, api_key=api_key)
 
         except HTTPException as e:
             response = JSONResponse(
@@ -319,6 +335,78 @@ class SecurityMiddleware:
         # Record usage for all keys (both managed and env keys)
         if result.key_hash:
             await auth_service.record_usage(result.key_hash, is_env_key=result.is_env_key)
+
+    def _extract_bearer_jwt(self, request: Request) -> str | None:
+        """Return the Bearer token if it looks like a CodeAPI JWT, else None.
+
+        Returns ``None`` (deferring to API-key auth) when:
+          - ``settings.codeapi_jwt_enabled`` is False, OR
+          - the Authorization header is missing / not ``Bearer``, OR
+          - the Bearer value does not structurally look like a JWT (three
+            base64 segments separated by dots). An attacker submitting a
+            random 40-char API key as ``Bearer foo`` should keep being
+            handled by the API-key path, not get a 401 from the JWT verifier.
+
+        Returns the raw token string otherwise; verification happens in
+        ``_authenticate_jwt``.
+        """
+        if not settings.codeapi_jwt_enabled:
+            return None
+        auth_header = request.headers.get("authorization") or ""
+        if not auth_header.lower().startswith("bearer "):
+            return None
+        token = auth_header.split(" ", 1)[1].strip()
+        # Import locally to keep middleware import-time cheap and to avoid
+        # a circular import if codeapi_jwt ever wants to log via middleware.
+        from ..services.codeapi_jwt import _looks_like_jwt
+
+        return token if _looks_like_jwt(token) else None
+
+    async def _authenticate_jwt(self, token: str, scope: dict) -> None:
+        """Verify a CodeAPI JWT and seed scope state.
+
+        Raises:
+            HTTPException(401): the token is invalid (expired, wrong
+                signature, wrong iss/aud, malformed).
+            HTTPException(500): CodeAPI JWT auth is enabled but no public
+                key is configured. This is a server-side bug; the client
+                did nothing wrong.
+        """
+        from ..services.codeapi_jwt import (
+            CodeApiJwtConfigurationError,
+            CodeApiJwtError,
+            verify,
+        )
+
+        try:
+            claims = verify(token)
+        except CodeApiJwtConfigurationError as exc:
+            logger.error("CodeAPI JWT misconfigured", error=str(exc))
+            raise HTTPException(
+                status_code=500,
+                detail="CodeAPI JWT auth is enabled but public key is not configured",
+            ) from exc
+        except CodeApiJwtError as exc:
+            raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+        # Seed request state. The JWT.sub IS the user identity — downstream
+        # code (exec endpoint, orchestrator) trusts this over the User-Id
+        # HTTP header because it is cryptographically signed.
+        # api_key_hash uses a short prefix of sha256(sub) for log aggregation
+        # without exposing the user id in metric dashboards.
+        sub_hash = hashlib.sha256(claims.sub.encode()).hexdigest()
+        scope_state = scope.get("state") or {}
+        scope_state["authenticated"] = True
+        scope_state["api_key"] = ""  # not an api-key auth path
+        scope_state["api_key_hash"] = f"jwt:{sub_hash[:16]}"
+        scope_state["is_env_key"] = False
+        scope_state["user_id"] = claims.sub
+        scope_state["auth_principal_source"] = "codeapi_jwt"
+        if claims.tenant_id and settings.codeapi_jwt_trust_tenant_id:
+            scope_state["tenant_id"] = claims.tenant_id
+        if claims.jti:
+            scope_state["jwt_jti"] = claims.jti
+        scope["state"] = scope_state
 
     def _extract_api_key(self, request: Request) -> str | None:
         """Extract API key from request headers.

--- a/src/models/exec.py
+++ b/src/models/exec.py
@@ -4,23 +4,53 @@
 from typing import Any, List, Optional
 
 # Third-party imports
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, computed_field
 
 
 class FileRef(BaseModel):
-    """File reference model for execution response."""
+    """File reference model for execution response.
+
+    LibreChat 0.8.5 (packages/data-provider/src/codeEnvRef.ts) expects
+    ``storage_session_id`` rather than ``session_id`` on each file ref;
+    we emit both for back-compat. ``resource_id``/``kind``/``version``
+    carry the LC ``CodeEnvFile`` discriminator into the response so
+    skill/agent attribution survives a generation round-trip.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str
     name: str
     path: str | None = None  # Make path optional
+    session_id: str | None = None
+    resource_id: str | None = None
+    kind: str | None = None  # 'skill' | 'agent' | 'user'
+    version: int | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def storage_session_id(self) -> str | None:
+        """LibreChat alias for session_id; expected by @librechat/agents."""
+        return self.session_id
 
 
 class RequestFile(BaseModel):
-    """Request file model."""
+    """Request file model.
+
+    Accepts both ``storage_session_id`` (LibreChat 0.8.5 convention) and
+    ``session_id`` (legacy) so old and new clients work side by side.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str
-    session_id: str
+    session_id: str = Field(
+        validation_alias=AliasChoices("storage_session_id", "session_id"),
+    )
     name: str
+    resource_id: str | None = None
+    kind: str | None = None  # 'skill' | 'agent' | 'user'
+    version: int | None = None
 
 
 class ExecRequest(BaseModel):

--- a/src/services/codeapi_jwt.py
+++ b/src/services/codeapi_jwt.py
@@ -1,0 +1,222 @@
+"""LibreChat CodeAPI JWT verifier.
+
+LibreChat 0.8.5 (``danny-avila/LibreChat#13028`` — *🔐 feat: Mint Code API
+Auth Tokens*) introduced signed JWT auth for its code-interpreter calls.
+The signer side lives in ``packages/api/src/auth/codeapi.ts``; this module
+is the verifier on the codeapi side.
+
+Wire shape
+----------
+
+Header:
+
+  ``Authorization: Bearer <jwt>``
+
+Where ``<jwt>`` is signed with **EdDSA** (Ed25519, the default) or
+**RS256**, and carries these claims::
+
+    {
+      "iss": "librechat",       # CODEAPI_JWT_ISSUER
+      "aud": "codeapi",         # CODEAPI_JWT_AUDIENCE
+      "sub": "<userId>",        # authenticated LC user id
+      "iat": <unix>,
+      "nbf": <unix>,
+      "exp": <unix>,            # iat + CODEAPI_JWT_TTL_SECONDS (<=300)
+      "jti": "<uuid>",
+      "tenant_id": "<tenant>",
+      "role": "USER" | "ADMIN" | ...,
+      "principal_source": "librechat_jwt" | "openid_reuse",
+      "auth_context_hash": "<sha256-hex>",
+      # optional: org_id, service_id, chc_user_id, plan_id
+    }
+
+JWT header carries ``kid`` for key rotation; we accept any kid the
+configured public key validates (single-key deployments). Future work
+could add a JWKS endpoint.
+
+Security notes
+--------------
+
+- We **pin the algorithm** to the operator-configured one
+  (``CODEAPI_JWT_ALGORITHM``) — never trust the header's ``alg`` to pick
+  an algorithm. This is the standard "alg confusion" defence.
+- We enforce ``iss``/``aud`` exactly and validate ``exp``/``nbf`` with
+  a small leeway (``codeapi_jwt_leeway_seconds``).
+- The public key is loaded once per process and cached. Operators rotate
+  keys by restarting the process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import jwt as pyjwt
+import structlog
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
+
+from ..config import settings
+
+logger = structlog.get_logger(__name__)
+
+
+# Concrete pyjwt errors we treat as "bad token, log at info, return 401".
+# Everything else (configuration / programming) is logged at error.
+_TOKEN_ERRORS: tuple[type[Exception], ...] = (
+    pyjwt.ExpiredSignatureError,
+    pyjwt.ImmatureSignatureError,
+    pyjwt.InvalidAudienceError,
+    pyjwt.InvalidIssuerError,
+    pyjwt.InvalidSignatureError,
+    pyjwt.InvalidTokenError,
+    pyjwt.DecodeError,
+)
+
+
+@dataclass(frozen=True)
+class JwtClaims:
+    """The subset of CodeAPI JWT claims downstream code consumes.
+
+    Kept narrow on purpose — the full claim set is for LibreChat's
+    auditing/billing model and we don't have a use for most fields.
+    """
+
+    sub: str  # LibreChat user id (the value LC otherwise sends as User-Id)
+    tenant_id: str | None
+    role: str | None
+    principal_source: str | None
+    jti: str | None  # request id (useful for log correlation)
+
+
+class CodeApiJwtError(Exception):
+    """Base error for the verifier — caller maps to HTTP 401."""
+
+
+class CodeApiJwtConfigurationError(CodeApiJwtError):
+    """Raised when JWT auth is enabled but no public key is configured."""
+
+
+def _looks_like_jwt(token: str) -> bool:
+    """Cheap structural check: 3 base64-ish segments separated by dots.
+
+    Lets callers distinguish "this Bearer is a JWT" from "this Bearer is
+    a plain API key" without paying the parse cost.
+    """
+    if not token or token.count(".") != 2:
+        return False
+    parts = token.split(".")
+    return all(part and len(part) >= 4 for part in parts)
+
+
+def _load_pem_or_jwk(raw: str) -> PublicKeyTypes:
+    """Parse the configured public key from PEM, JWK JSON, or file path."""
+    candidate = raw.strip()
+
+    # File path?
+    if (candidate.startswith("/") or candidate.startswith("./")) and os.path.isfile(candidate):
+        with open(candidate, encoding="utf-8") as fh:
+            candidate = fh.read().strip()
+
+    # JWK JSON?
+    if candidate.startswith("{"):
+        try:
+            jwk = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            raise CodeApiJwtConfigurationError(
+                f"codeapi_jwt_public_key looked like JWK JSON but failed to parse: {exc}"
+            ) from exc
+        algo = pyjwt.get_algorithm_by_name(settings.codeapi_jwt_algorithm)
+        return algo.from_jwk(jwk)
+
+    # PEM (or PKCS#1)?
+    try:
+        return serialization.load_pem_public_key(candidate.encode("utf-8"))
+    except ValueError as exc:
+        raise CodeApiJwtConfigurationError(
+            "codeapi_jwt_public_key is not a recognized PEM, JWK, or file path"
+        ) from exc
+
+
+@lru_cache(maxsize=1)
+def _get_public_key() -> PublicKeyTypes:
+    """Load and cache the configured public key.
+
+    Cached forever within the process — operators rotate by restarting.
+    The cache key is implicit (no args); changing the env var requires
+    a restart by design.
+    """
+    raw = settings.codeapi_jwt_public_key
+    if not raw:
+        raise CodeApiJwtConfigurationError(
+            "codeapi_jwt_enabled=true but codeapi_jwt_public_key is unset. "
+            "Provide the LibreChat-paired public key as PEM, JWK, or a file path."
+        )
+    return _load_pem_or_jwk(raw)
+
+
+def reset_public_key_cache() -> None:
+    """Drop the cached key. Tests use this to swap keys between runs."""
+    _get_public_key.cache_clear()
+
+
+def verify(token: str) -> JwtClaims:
+    """Verify a CodeAPI JWT and return the narrow claim subset.
+
+    Raises:
+        CodeApiJwtConfigurationError: server-side misconfiguration.
+            Caller should respond 500, not 401 — the client did nothing
+            wrong; we just can't tell who they are.
+        CodeApiJwtError: any token-side problem (expired, wrong issuer,
+            invalid signature, malformed). Caller maps to 401.
+    """
+    if not settings.codeapi_jwt_enabled:
+        raise CodeApiJwtError("CodeAPI JWT auth is disabled")
+
+    if not _looks_like_jwt(token):
+        # Caller should not have invoked us; treat as caller bug.
+        raise CodeApiJwtError("Bearer value is not a JWT (expected three base64 segments)")
+
+    public_key = _get_public_key()  # may raise CodeApiJwtConfigurationError
+
+    try:
+        claims = pyjwt.decode(
+            token,
+            key=public_key,
+            algorithms=[settings.codeapi_jwt_algorithm],  # alg pinning
+            issuer=settings.codeapi_jwt_issuer,
+            audience=settings.codeapi_jwt_audience,
+            leeway=settings.codeapi_jwt_leeway_seconds,
+            options={
+                "require": ["iss", "aud", "sub", "exp", "iat"],
+                "verify_signature": True,
+                "verify_exp": True,
+                "verify_nbf": True,
+                "verify_iss": True,
+                "verify_aud": True,
+            },
+        )
+    except _TOKEN_ERRORS as exc:
+        logger.info("CodeAPI JWT rejected", reason=type(exc).__name__, error=str(exc))
+        raise CodeApiJwtError(f"Invalid CodeAPI JWT: {exc}") from exc
+
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise CodeApiJwtError("CodeAPI JWT has empty sub claim")
+
+    return JwtClaims(
+        sub=sub,
+        tenant_id=_str_or_none(claims.get("tenant_id")),
+        role=_str_or_none(claims.get("role")),
+        principal_source=_str_or_none(claims.get("principal_source")),
+        jti=_str_or_none(claims.get("jti")),
+    )
+
+
+def _str_or_none(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/src/services/codeapi_jwt.py
+++ b/src/services/codeapi_jwt.py
@@ -136,9 +136,7 @@ def _load_pem_or_jwk(raw: str) -> PublicKeyTypes:
     try:
         return serialization.load_pem_public_key(candidate.encode("utf-8"))
     except ValueError as exc:
-        raise CodeApiJwtConfigurationError(
-            "codeapi_jwt_public_key is not a recognized PEM, JWK, or file path"
-        ) from exc
+        raise CodeApiJwtConfigurationError("codeapi_jwt_public_key is not a recognized PEM, JWK, or file path") from exc
 
 
 @lru_cache(maxsize=1)

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -235,8 +235,6 @@ class ExecutionOrchestrator:
         We only reuse a file-referenced or entity-referenced session if its
         recorded user_id matches the current request. When the request has no
         user_id we never reuse — always create a new session.
-
-        Compatible upstream fix: usnavy13/LibreCodeInterpreter#63.
         """
         request = ctx.request
 

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -217,13 +217,32 @@ class ExecutionOrchestrator:
 
         Session lookup priority:
         1. Use session_id from request (for explicit session continuity/state persistence)
-        2. Reuse session from file references (for file-based workflows)
-        3. Reuse session by entity_id (for session continuity within same entity)
+        2. Reuse session from file references, but ONLY if the session belongs to
+           the same user (prevents cross-user session sharing via shared agent files)
+        3. Reuse session by entity_id, but ONLY if the session belongs to
+           the same user (prevents collapsing multiple users of a shared agent
+           into the same execution context)
         4. Create new session
+
+        SECURITY: File references carry a session_id that indicates where the
+        file is *stored*, NOT which session to execute in. When multiple users
+        share an agent with attached files, every user's request carries the
+        same upload session_id. Blindly reusing that session would leak state,
+        generated files, and auto-rehydrated session files between users
+        (the file_ref.session_id reuse path is followed by `_mount_files`
+        re-hydrating every file under the chosen session_id from MinIO).
+
+        We only reuse a file-referenced or entity-referenced session if its
+        recorded user_id matches the current request. When the request has no
+        user_id we never reuse — always create a new session.
+
+        Compatible upstream fix: usnavy13/LibreCodeInterpreter#63.
         """
         request = ctx.request
 
-        # Priority 1: Use explicit session_id from request (for state persistence)
+        # Priority 1: Use explicit session_id from request (for state persistence).
+        # The client knows the session is theirs; an attacker would need to know
+        # both a victim's session_id AND bypass the auth layer (validated above).
         if request.session_id:
             try:
                 existing = await self.session_service.get_session(request.session_id)
@@ -240,38 +259,59 @@ class ExecutionOrchestrator:
                     error=str(e),
                 )
 
-        # Priority 2: Try to reuse session from files array
-        if request.files:
+        # Priority 2: Try to reuse session from files array, but only if the
+        # session was created by the same user. This enables same-user session
+        # continuity (e.g., upload-then-exec) while preventing cross-user
+        # sharing via agent-attached files that reference a shared upload session.
+        if request.files and request.user_id:
             for file_ref in request.files:
-                if file_ref.session_id:
-                    try:
-                        existing = await self.session_service.get_session(file_ref.session_id)
-                        if existing and existing.status.value == "active":
-                            logger.info(
-                                "Reusing session from file reference",
-                                session_id=file_ref.session_id,
-                            )
-                            return file_ref.session_id
-                    except Exception as e:
-                        logger.warning(
-                            "Error looking up session",
-                            session_id=file_ref.session_id,
-                            error=str(e),
-                        )
-
-        # Try to reuse session by entity_id (enables session continuity)
-        if request.entity_id:
-            try:
-                entity_sessions = await self.session_service.list_sessions_by_entity(request.entity_id, limit=1)
-                if entity_sessions:
-                    existing = entity_sessions[0]
-                    if existing.status.value == "active":
+                if not file_ref.session_id:
+                    continue
+                try:
+                    existing = await self.session_service.get_session(file_ref.session_id)
+                    if not (existing and existing.status.value == "active"):
+                        continue
+                    session_user = (existing.metadata or {}).get("user_id")
+                    if session_user and session_user == request.user_id:
                         logger.info(
-                            "Reusing session by entity_id",
-                            session_id=existing.session_id[:12],
+                            "Reusing session from file reference (same user)",
+                            session_id=file_ref.session_id[:12],
+                        )
+                        return file_ref.session_id
+                    logger.info(
+                        "Skipping file_ref session reuse (different user)",
+                        session_id=file_ref.session_id[:12],
+                        session_user=(session_user[:8] + "...") if session_user else None,
+                        request_user=request.user_id[:8] + "...",
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Error looking up session",
+                        session_id=file_ref.session_id,
+                        error=str(e),
+                    )
+
+        # Priority 3: Try to reuse session by entity_id, but only if the
+        # session was created by the same user. Without the user_id check,
+        # multiple users of a shared agent would converge on a single session
+        # and see each other's files/state.
+        if request.entity_id and request.user_id:
+            try:
+                # Pull a larger window than the previous "first match wins"
+                # heuristic so we can pick the user's own session even when
+                # the agent has been used by other users in between.
+                entity_sessions = await self.session_service.list_sessions_by_entity(request.entity_id, limit=10)
+                for candidate in entity_sessions:
+                    if candidate.status.value != "active":
+                        continue
+                    session_user = (candidate.metadata or {}).get("user_id")
+                    if session_user and session_user == request.user_id:
+                        logger.info(
+                            "Reusing session by entity_id (same user)",
+                            session_id=candidate.session_id[:12],
                             entity_id=request.entity_id,
                         )
-                        return existing.session_id
+                        return candidate.session_id
             except Exception as e:
                 logger.warning(
                     "Error looking up session by entity_id",
@@ -287,7 +327,11 @@ class ExecutionOrchestrator:
             metadata["user_id"] = request.user_id
 
         session = await self.session_service.create_session(SessionCreate(metadata=metadata))
-        logger.info("Created new session", session_id=session.session_id)
+        logger.info(
+            "Created new session",
+            session_id=session.session_id,
+            has_user_id=bool(request.user_id),
+        )
         return session.session_id
 
     async def _mount_files(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
@@ -300,12 +344,64 @@ class ExecutionOrchestrator:
         uploaded file associated with the execution session is re-hydrated
         from MinIO on each call, in addition to whatever the client
         explicitly referenced in request.files.
+
+        SECURITY: When a file_ref points at a session owned by a different
+        user (e.g. a request-forged or replayed reference), we skip mounting
+        it. This is defense-in-depth on top of _get_or_create_session — even
+        if the request lands on a fresh execution session, we must not copy
+        a foreign user's file content into it.
         """
+        request_user_id = ctx.request.user_id
+        # Cache user_id of foreign sessions to avoid repeated lookups when a
+        # request carries multiple file refs against the same upload session.
+        session_owner_cache: dict[str, str | None] = {}
+
+        async def _is_file_ref_authorized(file_session_id: str) -> bool:
+            """True if the file_ref's session is mountable by the current request.
+
+            - If request has no user_id, only allow refs whose session also has
+              no user_id (legacy / anonymous flow). This is the same posture
+              `_get_or_create_session` takes when it refuses to reuse foreign
+              sessions without an authenticated user_id.
+            - If request has a user_id, the session must either have the same
+              user_id or no user_id at all (legacy uploads predate the field).
+            """
+            if file_session_id == ctx.session_id:
+                return True
+            if file_session_id not in session_owner_cache:
+                try:
+                    foreign = await self.session_service.get_session(file_session_id)
+                    session_owner_cache[file_session_id] = (
+                        (foreign.metadata or {}).get("user_id") if foreign else None
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Error inspecting foreign session for ownership check",
+                        session_id=file_session_id[:12],
+                        error=str(e),
+                    )
+                    # Fail closed: if we can't verify, don't mount.
+                    return False
+            session_user = session_owner_cache[file_session_id]
+            if session_user is None:
+                # Legacy / anonymous upload. Allow for backward compatibility.
+                return True
+            return session_user == request_user_id
+
         mounted: list[dict[str, Any]] = []
         mounted_keys: set[tuple[str, str]] = set()
         mounted_filenames: set[str] = set()
 
         for file_ref in ctx.request.files:
+            if not await _is_file_ref_authorized(file_ref.session_id):
+                logger.warning(
+                    "Skipping file_ref from foreign-user session",
+                    session_id=file_ref.session_id[:12],
+                    file_id=file_ref.id,
+                    request_user=request_user_id[:8] + "..." if request_user_id else None,
+                )
+                continue
+
             # Get file info - try by ID first
             file_info = await self.file_service.get_file_info(file_ref.session_id, file_ref.id)
 

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -371,9 +371,7 @@ class ExecutionOrchestrator:
             if file_session_id not in session_owner_cache:
                 try:
                     foreign = await self.session_service.get_session(file_session_id)
-                    session_owner_cache[file_session_id] = (
-                        (foreign.metadata or {}).get("user_id") if foreign else None
-                    )
+                    session_owner_cache[file_session_id] = (foreign.metadata or {}).get("user_id") if foreign else None
                 except Exception as e:
                     logger.warning(
                         "Error inspecting foreign session for ownership check",

--- a/tests/unit/test_api_exec.py
+++ b/tests/unit/test_api_exec.py
@@ -297,3 +297,123 @@ class TestExecuteCodeEndpoint:
         call_args = mock_orchestrator.execute.call_args
         assert call_args.args[0].entity_id == "entity-123"
         assert call_args.args[0].user_id == "user-456"
+
+
+class TestUserIdHeaderFallback:
+    """LibreChat 0.8.5 sends user_id in the User-Id HTTP header, not in the
+    request body. exec.py must fall back to the header when the body field
+    is missing, so the cross-user session-isolation check in
+    orchestrator._get_or_create_session has a user_id to match against.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_id_falls_back_to_user_id_header(
+        self,
+        mock_session_service,
+        mock_file_service,
+        mock_execution_service,
+        mock_state_service,
+        mock_state_archival_service,
+    ):
+        """Body user_id is missing → exec.py copies User-Id header onto request."""
+        http_request = MagicMock(spec=Request)
+        http_request.state = MagicMock()
+        http_request.state.api_key_hash = "abc123hash"
+        http_request.state.is_env_key = False
+        http_request.headers = {"user-id": "user-from-header", "x-user-id": None}
+
+        exec_request = ExecRequest(code="print('hi')", lang="py")
+        expected = ExecResponse(session_id="s", stdout="", stderr="")
+
+        with patch("src.api.exec.ExecutionOrchestrator") as MockOrchestrator:
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.execute = AsyncMock(return_value=expected)
+            MockOrchestrator.return_value = mock_orchestrator
+
+            await execute_code(
+                request=exec_request,
+                http_request=http_request,
+                session_service=mock_session_service,
+                file_service=mock_file_service,
+                execution_service=mock_execution_service,
+                state_service=mock_state_service,
+                state_archival_service=mock_state_archival_service,
+            )
+
+        passed = mock_orchestrator.execute.call_args.args[0]
+        assert passed.user_id == "user-from-header"
+
+    @pytest.mark.asyncio
+    async def test_user_id_falls_back_to_x_user_id_header(
+        self,
+        mock_session_service,
+        mock_file_service,
+        mock_execution_service,
+        mock_state_service,
+        mock_state_archival_service,
+    ):
+        """X-User-Id is accepted when User-Id is absent (X- naming convention)."""
+        http_request = MagicMock(spec=Request)
+        http_request.state = MagicMock()
+        http_request.state.api_key_hash = "abc123hash"
+        http_request.state.is_env_key = False
+        http_request.headers = {"user-id": None, "x-user-id": "user-x"}
+
+        exec_request = ExecRequest(code="print('hi')", lang="py")
+        expected = ExecResponse(session_id="s", stdout="", stderr="")
+
+        with patch("src.api.exec.ExecutionOrchestrator") as MockOrchestrator:
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.execute = AsyncMock(return_value=expected)
+            MockOrchestrator.return_value = mock_orchestrator
+
+            await execute_code(
+                request=exec_request,
+                http_request=http_request,
+                session_service=mock_session_service,
+                file_service=mock_file_service,
+                execution_service=mock_execution_service,
+                state_service=mock_state_service,
+                state_archival_service=mock_state_archival_service,
+            )
+
+        passed = mock_orchestrator.execute.call_args.args[0]
+        assert passed.user_id == "user-x"
+
+    @pytest.mark.asyncio
+    async def test_body_user_id_wins_over_header(
+        self,
+        mock_session_service,
+        mock_file_service,
+        mock_execution_service,
+        mock_state_service,
+        mock_state_archival_service,
+    ):
+        """When the request body already carries user_id, the header is ignored.
+        This preserves the existing API contract for direct-API callers."""
+        http_request = MagicMock(spec=Request)
+        http_request.state = MagicMock()
+        http_request.state.api_key_hash = "abc123hash"
+        http_request.state.is_env_key = False
+        http_request.headers = {"user-id": "user-from-header", "x-user-id": None}
+
+        exec_request = ExecRequest(code="print('hi')", lang="py", user_id="user-from-body")
+        expected = ExecResponse(session_id="s", stdout="", stderr="")
+
+        with patch("src.api.exec.ExecutionOrchestrator") as MockOrchestrator:
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.execute = AsyncMock(return_value=expected)
+            MockOrchestrator.return_value = mock_orchestrator
+
+            await execute_code(
+                request=exec_request,
+                http_request=http_request,
+                session_service=mock_session_service,
+                file_service=mock_file_service,
+                execution_service=mock_execution_service,
+                state_service=mock_state_service,
+                state_archival_service=mock_state_archival_service,
+            )
+
+        passed = mock_orchestrator.execute.call_args.args[0]
+        assert passed.user_id == "user-from-body"

--- a/tests/unit/test_api_exec.py
+++ b/tests/unit/test_api_exec.py
@@ -13,11 +13,19 @@ from src.models.exec import ExecRequest, ExecResponse
 
 @pytest.fixture
 def mock_request():
-    """Create a mock HTTP request."""
+    """Create a mock HTTP request.
+
+    ``state.user_id`` is explicitly set to None so the JWT-precedence
+    check in exec.py (``getattr(http_request.state, "user_id", None)``)
+    correctly falls through to header/body resolution. Without this,
+    MagicMock would auto-create a truthy attribute and short-circuit
+    the resolution chain.
+    """
     request = MagicMock(spec=Request)
     request.state = MagicMock()
     request.state.api_key_hash = "abc123hash"
     request.state.is_env_key = False
+    request.state.user_id = None
     return request
 
 
@@ -320,6 +328,7 @@ class TestUserIdHeaderFallback:
         http_request.state = MagicMock()
         http_request.state.api_key_hash = "abc123hash"
         http_request.state.is_env_key = False
+        http_request.state.user_id = None
         http_request.headers = {"user-id": "user-from-header", "x-user-id": None}
 
         exec_request = ExecRequest(code="print('hi')", lang="py")
@@ -357,6 +366,7 @@ class TestUserIdHeaderFallback:
         http_request.state = MagicMock()
         http_request.state.api_key_hash = "abc123hash"
         http_request.state.is_env_key = False
+        http_request.state.user_id = None
         http_request.headers = {"user-id": None, "x-user-id": "user-x"}
 
         exec_request = ExecRequest(code="print('hi')", lang="py")
@@ -395,6 +405,7 @@ class TestUserIdHeaderFallback:
         http_request.state = MagicMock()
         http_request.state.api_key_hash = "abc123hash"
         http_request.state.is_env_key = False
+        http_request.state.user_id = None
         http_request.headers = {"user-id": "user-from-header", "x-user-id": None}
 
         exec_request = ExecRequest(code="print('hi')", lang="py", user_id="user-from-body")
@@ -417,3 +428,89 @@ class TestUserIdHeaderFallback:
 
         passed = mock_orchestrator.execute.call_args.args[0]
         assert passed.user_id == "user-from-body"
+
+
+class TestJwtUserIdPrecedence:
+    """request.state.user_id (set by SecurityMiddleware after JWT verification)
+    is cryptographically authenticated and MUST override both the request body
+    user_id and the User-Id header. Without this, an attacker holding a valid
+    JWT for user-A could pass user_id=victim in the request body and operate
+    against the victim's sessions."""
+
+    @pytest.mark.asyncio
+    async def test_jwt_user_id_overrides_body_user_id(
+        self,
+        mock_session_service,
+        mock_file_service,
+        mock_execution_service,
+        mock_state_service,
+        mock_state_archival_service,
+    ):
+        """Attacker with JWT for user-A submits body user_id=user-victim.
+        Resolved user_id must be user-A (the JWT's sub)."""
+        http_request = MagicMock(spec=Request)
+        http_request.state = MagicMock()
+        http_request.state.api_key_hash = "jwt:abc"
+        http_request.state.is_env_key = False
+        http_request.state.user_id = "user-A-jwt"  # set by middleware
+        http_request.headers = {"user-id": None, "x-user-id": None}
+
+        exec_request = ExecRequest(code="print('x')", lang="py", user_id="user-victim")
+        expected = ExecResponse(session_id="s", stdout="", stderr="")
+
+        with patch("src.api.exec.ExecutionOrchestrator") as MockOrchestrator:
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.execute = AsyncMock(return_value=expected)
+            MockOrchestrator.return_value = mock_orchestrator
+
+            await execute_code(
+                request=exec_request,
+                http_request=http_request,
+                session_service=mock_session_service,
+                file_service=mock_file_service,
+                execution_service=mock_execution_service,
+                state_service=mock_state_service,
+                state_archival_service=mock_state_archival_service,
+            )
+
+        passed = mock_orchestrator.execute.call_args.args[0]
+        assert passed.user_id == "user-A-jwt"
+
+    @pytest.mark.asyncio
+    async def test_jwt_user_id_overrides_user_id_header(
+        self,
+        mock_session_service,
+        mock_file_service,
+        mock_execution_service,
+        mock_state_service,
+        mock_state_archival_service,
+    ):
+        """Attacker sets User-Id: victim but holds valid JWT for user-A.
+        JWT wins; header is ignored."""
+        http_request = MagicMock(spec=Request)
+        http_request.state = MagicMock()
+        http_request.state.api_key_hash = "jwt:abc"
+        http_request.state.is_env_key = False
+        http_request.state.user_id = "user-A-jwt"
+        http_request.headers = {"user-id": "user-victim", "x-user-id": None}
+
+        exec_request = ExecRequest(code="print('x')", lang="py")
+        expected = ExecResponse(session_id="s", stdout="", stderr="")
+
+        with patch("src.api.exec.ExecutionOrchestrator") as MockOrchestrator:
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.execute = AsyncMock(return_value=expected)
+            MockOrchestrator.return_value = mock_orchestrator
+
+            await execute_code(
+                request=exec_request,
+                http_request=http_request,
+                session_service=mock_session_service,
+                file_service=mock_file_service,
+                execution_service=mock_execution_service,
+                state_service=mock_state_service,
+                state_archival_service=mock_state_archival_service,
+            )
+
+        passed = mock_orchestrator.execute.call_args.args[0]
+        assert passed.user_id == "user-A-jwt"

--- a/tests/unit/test_api_files.py
+++ b/tests/unit/test_api_files.py
@@ -51,6 +51,21 @@ def mock_upload_file():
 
 
 @pytest.fixture
+def mock_http_request():
+    """Anonymous HTTP Request (no JWT-resolved user_id).
+
+    upload_file now reads request.state.user_id (set by SecurityMiddleware
+    after JWT verification) before falling through to header/body
+    resolution. Tests that don't exercise the JWT path use this anonymous
+    fixture so resolution behaves as it did pre-JWT.
+    """
+    request = MagicMock()
+    request.state = MagicMock()
+    request.state.user_id = None
+    return request
+
+
+@pytest.fixture
 def mock_file_info():
     """Create a mock file info object."""
     info = MagicMock()
@@ -116,9 +131,12 @@ class TestUploadFile:
     """Tests for upload_file endpoint."""
 
     @pytest.mark.asyncio
-    async def test_upload_single_file(self, mock_file_service, mock_session_service, mock_upload_file):
+    async def test_upload_single_file(
+        self, mock_file_service, mock_session_service, mock_upload_file, mock_http_request
+    ):
         """Test uploading a single file."""
         result = await upload_file(
+            request=mock_http_request,
             file=mock_upload_file,
             files=None,
             entity_id="entity-123",
@@ -144,7 +162,7 @@ class TestUploadFile:
         ],
     )
     async def test_upload_sanitizes_filename_before_storage(
-        self, mock_file_service, mock_session_service, original, expected
+        self, mock_file_service, mock_session_service, mock_http_request, original, expected
     ):
         """Test that filenames with special characters are sanitized before storing."""
         file = MagicMock(spec=UploadFile)
@@ -154,6 +172,7 @@ class TestUploadFile:
         file.read = AsyncMock(return_value=b"a,b,c")
 
         result = await upload_file(
+            request=mock_http_request,
             file=file,
             files=None,
             entity_id=None,
@@ -169,11 +188,14 @@ class TestUploadFile:
         assert result["files"][0]["filename"] == expected
 
     @pytest.mark.asyncio
-    async def test_upload_multiple_files(self, mock_file_service, mock_session_service, mock_upload_file):
+    async def test_upload_multiple_files(
+        self, mock_file_service, mock_session_service, mock_upload_file, mock_http_request
+    ):
         """Test uploading multiple files."""
         files = [mock_upload_file, mock_upload_file]
 
         result = await upload_file(
+            request=mock_http_request,
             file=None,
             files=files,
             entity_id="entity-123",
@@ -186,10 +208,11 @@ class TestUploadFile:
         mock_session_service.create_session.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_upload_no_files(self, mock_file_service):
+    async def test_upload_no_files(self, mock_file_service, mock_http_request):
         """Test upload with no files raises 422."""
         with pytest.raises(HTTPException) as exc_info:
             await upload_file(
+                request=mock_http_request,
                 file=None,
                 files=None,
                 entity_id="entity-123",
@@ -199,7 +222,7 @@ class TestUploadFile:
         assert exc_info.value.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_upload_file_too_large(self, mock_file_service, mock_upload_file):
+    async def test_upload_file_too_large(self, mock_file_service, mock_upload_file, mock_http_request):
         """Test upload file too large raises 413."""
         mock_upload_file.size = 500 * 1024 * 1024  # 500MB
 
@@ -208,6 +231,7 @@ class TestUploadFile:
 
             with pytest.raises(HTTPException) as exc_info:
                 await upload_file(
+                    request=mock_http_request,
                     file=mock_upload_file,
                     files=None,
                     entity_id="entity-123",
@@ -217,7 +241,7 @@ class TestUploadFile:
             assert exc_info.value.status_code == 413
 
     @pytest.mark.asyncio
-    async def test_upload_too_many_files(self, mock_file_service, mock_upload_file):
+    async def test_upload_too_many_files(self, mock_file_service, mock_upload_file, mock_http_request):
         """Test upload too many files raises 413."""
         files = [mock_upload_file] * 100
 
@@ -227,6 +251,7 @@ class TestUploadFile:
 
             with pytest.raises(HTTPException) as exc_info:
                 await upload_file(
+                    request=mock_http_request,
                     file=None,
                     files=files,
                     entity_id="entity-123",
@@ -236,7 +261,9 @@ class TestUploadFile:
             assert exc_info.value.status_code == 413
 
     @pytest.mark.asyncio
-    async def test_upload_file_service_error(self, mock_file_service, mock_session_service, mock_upload_file):
+    async def test_upload_file_service_error(
+        self, mock_file_service, mock_session_service, mock_upload_file, mock_http_request
+    ):
         """Test upload file service error raises 500."""
         mock_file_service.store_uploaded_file.side_effect = Exception("Storage error")
 
@@ -246,6 +273,7 @@ class TestUploadFile:
 
             with pytest.raises(HTTPException) as exc_info:
                 await upload_file(
+                    request=mock_http_request,
                     file=mock_upload_file,
                     files=None,
                     entity_id="entity-123",

--- a/tests/unit/test_codeapi_jwt.py
+++ b/tests/unit/test_codeapi_jwt.py
@@ -1,0 +1,373 @@
+"""Unit tests for the CodeAPI JWT verifier (``src/services/codeapi_jwt.py``).
+
+These tests mint signed tokens with the same shape LibreChat 0.8.5 emits
+(``packages/api/src/auth/codeapi.ts``) and run them through our verifier.
+Both EdDSA (the default) and RS256 paths are covered.
+
+We mock ``src.services.codeapi_jwt.settings`` rather than the global
+``src.config.settings`` so changing one test's config doesn't bleed into
+the next.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
+
+from src.services import codeapi_jwt
+from src.services.codeapi_jwt import (
+    CodeApiJwtConfigurationError,
+    CodeApiJwtError,
+    JwtClaims,
+    _looks_like_jwt,
+    reset_public_key_cache,
+    verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def _ed25519_keypair() -> tuple[str, str]:
+    """Generate an Ed25519 keypair, return (private PEM, public PEM)."""
+    private = ed25519.Ed25519PrivateKey.generate()
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+def _rsa_keypair() -> tuple[str, str]:
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+def _mint(
+    private_pem: str,
+    *,
+    algorithm: str = "EdDSA",
+    issuer: str = "librechat",
+    audience: str = "codeapi",
+    sub: str = "user_123",
+    tenant_id: str | None = "tenant_abc",
+    extra: dict[str, Any] | None = None,
+    ttl: int = 300,
+    iat_offset: int = 0,
+) -> str:
+    """Mint a token mirroring LibreChat's signer shape."""
+    now = int(time.time()) + iat_offset
+    claims: dict[str, Any] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": sub,
+        "iat": now,
+        "nbf": now,
+        "exp": now + ttl,
+        "jti": "test-jti",
+        "role": "USER",
+        "principal_source": "librechat_jwt",
+        "auth_context_hash": "deadbeef",
+    }
+    if tenant_id:
+        claims["tenant_id"] = tenant_id
+    if extra:
+        claims.update(extra)
+    return pyjwt.encode(claims, private_pem, algorithm=algorithm, headers={"kid": "test-kid"})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: configure settings + load public key
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def configured(request):
+    """Configure ``codeapi_jwt`` for one test and reset the key cache after.
+
+    Parametrize via marker if needed; default values match LC's defaults.
+    """
+    algorithm = getattr(request, "param", {}).get("algorithm", "EdDSA")
+    if algorithm == "EdDSA":
+        private_pem, public_pem = _ed25519_keypair()
+    elif algorithm == "RS256":
+        private_pem, public_pem = _rsa_keypair()
+    else:
+        raise ValueError(f"unsupported test algorithm: {algorithm}")
+
+    with patch.object(codeapi_jwt, "settings") as mock_settings:
+        mock_settings.codeapi_jwt_enabled = True
+        mock_settings.codeapi_jwt_public_key = public_pem
+        mock_settings.codeapi_jwt_algorithm = algorithm
+        mock_settings.codeapi_jwt_issuer = "librechat"
+        mock_settings.codeapi_jwt_audience = "codeapi"
+        mock_settings.codeapi_jwt_leeway_seconds = 10
+        reset_public_key_cache()
+        try:
+            yield {
+                "private_pem": private_pem,
+                "public_pem": public_pem,
+                "algorithm": algorithm,
+                "settings": mock_settings,
+            }
+        finally:
+            reset_public_key_cache()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyEdDSA:
+    def test_valid_token_returns_claims(self, configured):
+        token = _mint(configured["private_pem"])
+        claims = verify(token)
+        assert isinstance(claims, JwtClaims)
+        assert claims.sub == "user_123"
+        assert claims.tenant_id == "tenant_abc"
+        assert claims.role == "USER"
+        assert claims.principal_source == "librechat_jwt"
+        assert claims.jti == "test-jti"
+
+
+@pytest.mark.parametrize("configured", [{"algorithm": "RS256"}], indirect=True)
+class TestVerifyRS256:
+    def test_valid_rs256_token_returns_claims(self, configured):
+        token = _mint(configured["private_pem"], algorithm="RS256")
+        claims = verify(token)
+        assert claims.sub == "user_123"
+
+
+# ---------------------------------------------------------------------------
+# Token-side failures (should raise CodeApiJwtError → 401)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRejections:
+    def test_expired(self, configured):
+        token = _mint(configured["private_pem"], ttl=1, iat_offset=-3600)
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+    def test_wrong_issuer(self, configured):
+        token = _mint(configured["private_pem"], issuer="evil-issuer")
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+    def test_wrong_audience(self, configured):
+        token = _mint(configured["private_pem"], audience="wrong-audience")
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+    def test_invalid_signature_via_different_key(self, configured):
+        # Mint with a *different* private key — signature won't match.
+        other_priv, _ = _ed25519_keypair()
+        token = _mint(other_priv)
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+    def test_malformed_token_not_three_segments(self, configured):
+        with pytest.raises(CodeApiJwtError):
+            verify("not.a.jwt.because.too.many.dots")
+
+    def test_empty_sub(self, configured):
+        token = _mint(configured["private_pem"], sub="")
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+    def test_alg_confusion_attack_rejected(self, configured):
+        """Attacker hand-crafts an HS256 token using the public key as the
+        HMAC secret. PyJWT's high-level encode now blocks this, but a hand-
+        rolled signer can still produce the malicious payload. Our verifier
+        pins alg=EdDSA so it must reject regardless of how the bytes got there.
+        """
+        import base64
+        import hashlib
+        import hmac
+        import json
+
+        def _b64(payload: bytes) -> str:
+            return base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+
+        header = _b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+        claims = _b64(
+            json.dumps(
+                {
+                    "iss": "librechat",
+                    "aud": "codeapi",
+                    "sub": "user_123",
+                    "iat": int(time.time()),
+                    "exp": int(time.time()) + 60,
+                }
+            ).encode()
+        )
+        signing_input = f"{header}.{claims}".encode()
+        signature = _b64(
+            hmac.new(
+                configured["public_pem"].encode(),
+                signing_input,
+                hashlib.sha256,
+            ).digest()
+        )
+        attacker_token = f"{header}.{claims}.{signature}"
+        with pytest.raises(CodeApiJwtError):
+            verify(attacker_token)
+
+    def test_missing_required_claim(self, configured):
+        """exp is required; mint without it."""
+        private_pem = configured["private_pem"]
+        # Build claims manually, omitting exp.
+        token = pyjwt.encode(
+            {
+                "iss": "librechat",
+                "aud": "codeapi",
+                "sub": "user_123",
+                "iat": int(time.time()),
+            },
+            private_pem,
+            algorithm="EdDSA",
+        )
+        with pytest.raises(CodeApiJwtError):
+            verify(token)
+
+
+# ---------------------------------------------------------------------------
+# Configuration failures (should raise CodeApiJwtConfigurationError → 500)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurationErrors:
+    def test_enabled_but_no_public_key(self):
+        with patch.object(codeapi_jwt, "settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            mock_settings.codeapi_jwt_public_key = None
+            mock_settings.codeapi_jwt_algorithm = "EdDSA"
+            mock_settings.codeapi_jwt_issuer = "librechat"
+            mock_settings.codeapi_jwt_audience = "codeapi"
+            mock_settings.codeapi_jwt_leeway_seconds = 10
+            reset_public_key_cache()
+            with pytest.raises(CodeApiJwtConfigurationError):
+                verify("aaaa.bbbb.cccc")
+
+    def test_disabled_raises_codeapi_jwt_error(self):
+        with patch.object(codeapi_jwt, "settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = False
+            mock_settings.codeapi_jwt_public_key = None
+            reset_public_key_cache()
+            with pytest.raises(CodeApiJwtError):
+                verify("aaaa.bbbb.cccc")
+
+    def test_garbage_public_key_raises_configuration_error(self):
+        with patch.object(codeapi_jwt, "settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            mock_settings.codeapi_jwt_public_key = "this is not a key"
+            mock_settings.codeapi_jwt_algorithm = "EdDSA"
+            mock_settings.codeapi_jwt_issuer = "librechat"
+            mock_settings.codeapi_jwt_audience = "codeapi"
+            mock_settings.codeapi_jwt_leeway_seconds = 10
+            reset_public_key_cache()
+            with pytest.raises(CodeApiJwtConfigurationError):
+                verify("aaaa.bbbb.cccc")
+
+
+# ---------------------------------------------------------------------------
+# Key-format support — PEM, JWK, file path
+# ---------------------------------------------------------------------------
+
+
+class TestKeyFormats:
+    def test_pem_format(self, configured):
+        """Already covered by configured fixture but pin explicitly."""
+        token = _mint(configured["private_pem"])
+        assert verify(token).sub == "user_123"
+
+    def test_jwk_json_format(self):
+        # Generate keypair, export public as JWK JSON, configure verifier with it.
+        private = ed25519.Ed25519PrivateKey.generate()
+        private_pem = private.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        public_jwk = pyjwt.algorithms.OKPAlgorithm().to_jwk(private.public_key())
+
+        with patch.object(codeapi_jwt, "settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            # to_jwk may already return a string; normalize.
+            mock_settings.codeapi_jwt_public_key = (
+                public_jwk if isinstance(public_jwk, str) else json.dumps(public_jwk)
+            )
+            mock_settings.codeapi_jwt_algorithm = "EdDSA"
+            mock_settings.codeapi_jwt_issuer = "librechat"
+            mock_settings.codeapi_jwt_audience = "codeapi"
+            mock_settings.codeapi_jwt_leeway_seconds = 10
+            reset_public_key_cache()
+
+            token = _mint(private_pem)
+            assert verify(token).sub == "user_123"
+
+    def test_file_path(self, tmp_path):
+        private_pem, public_pem = _ed25519_keypair()
+        key_file = tmp_path / "codeapi.pem"
+        key_file.write_text(public_pem)
+
+        with patch.object(codeapi_jwt, "settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            mock_settings.codeapi_jwt_public_key = str(key_file)
+            mock_settings.codeapi_jwt_algorithm = "EdDSA"
+            mock_settings.codeapi_jwt_issuer = "librechat"
+            mock_settings.codeapi_jwt_audience = "codeapi"
+            mock_settings.codeapi_jwt_leeway_seconds = 10
+            reset_public_key_cache()
+
+            token = _mint(private_pem)
+            assert verify(token).sub == "user_123"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeJwt:
+    @pytest.mark.parametrize("token", ["", "no-dots", "one.dot", "a.b.c.d"])
+    def test_rejects_non_jwt(self, token):
+        assert _looks_like_jwt(token) is False
+
+    def test_accepts_three_segments(self):
+        assert _looks_like_jwt("aaaa.bbbb.cccc") is True
+
+    def test_rejects_empty_segment(self):
+        assert _looks_like_jwt("a..c") is False

--- a/tests/unit/test_codeapi_jwt.py
+++ b/tests/unit/test_codeapi_jwt.py
@@ -31,7 +31,6 @@ from src.services.codeapi_jwt import (
     verify,
 )
 
-
 # ---------------------------------------------------------------------------
 # Key helpers
 # ---------------------------------------------------------------------------
@@ -326,9 +325,7 @@ class TestKeyFormats:
         with patch.object(codeapi_jwt, "settings") as mock_settings:
             mock_settings.codeapi_jwt_enabled = True
             # to_jwk may already return a string; normalize.
-            mock_settings.codeapi_jwt_public_key = (
-                public_jwk if isinstance(public_jwk, str) else json.dumps(public_jwk)
-            )
+            mock_settings.codeapi_jwt_public_key = public_jwk if isinstance(public_jwk, str) else json.dumps(public_jwk)
             mock_settings.codeapi_jwt_algorithm = "EdDSA"
             mock_settings.codeapi_jwt_issuer = "librechat"
             mock_settings.codeapi_jwt_audience = "codeapi"

--- a/tests/unit/test_cross_session_files.py
+++ b/tests/unit/test_cross_session_files.py
@@ -24,6 +24,20 @@ from src.models.files import FileInfo
 from src.services.orchestrator import ExecutionContext, ExecutionOrchestrator
 
 
+def _anon_http_request():
+    """Build a MagicMock HTTP request with no JWT-resolved user_id.
+
+    upload_file/upload_files_batch now take a `request: Request` parameter
+    and read `request.state.user_id` first (set by SecurityMiddleware
+    after JWT verification). Tests that don't exercise the JWT path
+    pass an anonymous request so resolution falls through to headers.
+    """
+    request = MagicMock()
+    request.state = MagicMock()
+    request.state.user_id = None
+    return request
+
+
 @pytest.fixture
 def mock_session_service():
     service = MagicMock()
@@ -279,6 +293,7 @@ class TestUploadSessionReuse:
         mock_file.read = AsyncMock(return_value=b"csv data")
 
         result = await upload_file(
+            request=_anon_http_request(),
             file=mock_file,
             files=None,
             entity_id="conversation-123",
@@ -322,6 +337,7 @@ class TestUploadSessionReuse:
         mock_file.read = AsyncMock(return_value=b"csv data")
 
         result = await upload_file(
+            request=_anon_http_request(),
             file=mock_file,
             files=None,
             entity_id="conversation-123",
@@ -359,6 +375,7 @@ class TestUploadSessionReuse:
         mock_file.read = AsyncMock(return_value=b"csv data")
 
         await upload_file(
+            request=_anon_http_request(),
             file=mock_file,
             files=None,
             entity_id="conv-1",
@@ -394,6 +411,7 @@ class TestUploadSessionReuse:
         mock_file.read = AsyncMock(return_value=b"csv data")
 
         result = await upload_file(
+            request=_anon_http_request(),
             file=mock_file,
             files=None,
             entity_id=None,
@@ -429,6 +447,7 @@ class TestUploadSessionReuse:
         mock_file.read = AsyncMock(return_value=b"csv data")
 
         result = await upload_file(
+            request=_anon_http_request(),
             file=mock_file,
             files=None,
             entity_id="conversation-123",

--- a/tests/unit/test_cross_session_files.py
+++ b/tests/unit/test_cross_session_files.py
@@ -119,6 +119,12 @@ class TestCrossSessionFileConsolidation:
         mock_file_service.get_file_info.side_effect = get_file_info_side_effect
         mock_file_service.get_file_content.return_value = b"csv data"
 
+        # Legacy pre-user_id sessions: session lookup returns None so the
+        # authorization check treats them as legacy/anonymous and allows
+        # cross-session mount (backward compatibility). The issue-#34
+        # scenario predates the user_id ownership concept.
+        orchestrator.session_service.get_session.return_value = None
+
         # Create request with files from two different sessions
         request = ExecRequest(
             code="import pandas as pd; df = pd.read_csv('data_b.csv')",
@@ -216,6 +222,10 @@ class TestCrossSessionFileConsolidation:
         mock_file_service.get_file_content.return_value = b"csv data"
         mock_file_service.store_uploaded_file.side_effect = Exception("MinIO error")
 
+        # Legacy session (no user_id metadata) — see comment in the
+        # consolidation test above.
+        orchestrator.session_service.get_session.return_value = None
+
         request = ExecRequest(
             code="print('hello')",
             lang="python",
@@ -240,14 +250,20 @@ class TestUploadSessionReuse:
     """Tests for upload endpoint reusing sessions by entity_id."""
 
     @pytest.mark.asyncio
-    async def test_upload_reuses_session_with_entity_id(self):
-        """When entity_id is provided, upload should reuse existing session."""
+    async def test_upload_reuses_session_with_entity_id_same_user(self):
+        """When entity_id and User-Id are provided AND the existing session
+        was created by the same user, upload should reuse it.
+
+        Cross-user sharing via a shared entity_id is now blocked (see
+        test_upload_does_NOT_reuse_session_for_different_user below).
+        """
         from src.api.files import upload_file
 
         existing_session = MagicMock()
         existing_session.session_id = "existing-session"
         existing_session.status = MagicMock()
         existing_session.status.value = "active"
+        existing_session.metadata = {"user_id": "user-A", "entity_id": "conversation-123"}
 
         mock_session_service = MagicMock()
         mock_session_service.list_sessions_by_entity = AsyncMock(return_value=[existing_session])
@@ -266,6 +282,8 @@ class TestUploadSessionReuse:
             file=mock_file,
             files=None,
             entity_id="conversation-123",
+            user_id_header="user-A",
+            x_user_id_header=None,
             file_service=mock_file_service,
             session_service=mock_session_service,
         )
@@ -273,6 +291,87 @@ class TestUploadSessionReuse:
         # Should reuse existing session, not create a new one
         mock_session_service.create_session.assert_not_called()
         assert result["session_id"] == "existing-session"
+
+    @pytest.mark.asyncio
+    async def test_upload_does_NOT_reuse_session_for_different_user(self):
+        """SECURITY: same entity_id shared across users must NOT collapse
+        them into one session. User-B uploading must create a fresh session
+        even though user-A's session exists for the same entity_id."""
+        from src.api.files import upload_file
+
+        a_session = MagicMock()
+        a_session.session_id = "session-by-A"
+        a_session.status = MagicMock()
+        a_session.status.value = "active"
+        a_session.metadata = {"user_id": "user-A", "entity_id": "conversation-123"}
+
+        new_session = MagicMock()
+        new_session.session_id = "new-for-B"
+
+        mock_session_service = MagicMock()
+        mock_session_service.list_sessions_by_entity = AsyncMock(return_value=[a_session])
+        mock_session_service.create_session = AsyncMock(return_value=new_session)
+
+        mock_file_service = MagicMock()
+        mock_file_service.store_uploaded_file = AsyncMock(return_value="file-123")
+
+        mock_file = MagicMock()
+        mock_file.filename = "test.csv"
+        mock_file.content_type = "text/csv"
+        mock_file.size = 100
+        mock_file.read = AsyncMock(return_value=b"csv data")
+
+        result = await upload_file(
+            file=mock_file,
+            files=None,
+            entity_id="conversation-123",
+            user_id_header="user-B",
+            x_user_id_header=None,
+            file_service=mock_file_service,
+            session_service=mock_session_service,
+        )
+
+        # Must create a fresh session for user-B; must NOT reuse user-A's.
+        mock_session_service.create_session.assert_called_once()
+        assert result["session_id"] == "new-for-B"
+
+    @pytest.mark.asyncio
+    async def test_upload_persists_user_id_on_session(self):
+        """User-Id header is persisted on session.metadata.user_id so the
+        cross-user isolation check at exec-time can recognize ownership."""
+        from src.api.files import upload_file
+        from src.models.session import SessionCreate
+
+        new_session = MagicMock()
+        new_session.session_id = "new-session"
+
+        mock_session_service = MagicMock()
+        mock_session_service.list_sessions_by_entity = AsyncMock(return_value=[])
+        mock_session_service.create_session = AsyncMock(return_value=new_session)
+
+        mock_file_service = MagicMock()
+        mock_file_service.store_uploaded_file = AsyncMock(return_value="file-123")
+
+        mock_file = MagicMock()
+        mock_file.filename = "test.csv"
+        mock_file.content_type = "text/csv"
+        mock_file.size = 100
+        mock_file.read = AsyncMock(return_value=b"csv data")
+
+        await upload_file(
+            file=mock_file,
+            files=None,
+            entity_id="conv-1",
+            user_id_header="user-A",
+            x_user_id_header=None,
+            file_service=mock_file_service,
+            session_service=mock_session_service,
+        )
+
+        call = mock_session_service.create_session.call_args
+        sc: SessionCreate = call.args[0]
+        assert sc.metadata.get("user_id") == "user-A"
+        assert sc.metadata.get("entity_id") == "conv-1"
 
     @pytest.mark.asyncio
     async def test_upload_creates_session_without_entity_id(self):
@@ -298,6 +397,8 @@ class TestUploadSessionReuse:
             file=mock_file,
             files=None,
             entity_id=None,
+            user_id_header=None,
+            x_user_id_header=None,
             file_service=mock_file_service,
             session_service=mock_session_service,
         )
@@ -331,6 +432,8 @@ class TestUploadSessionReuse:
             file=mock_file,
             files=None,
             entity_id="conversation-123",
+            user_id_header="user-A",
+            x_user_id_header=None,
             file_service=mock_file_service,
             session_service=mock_session_service,
         )

--- a/tests/unit/test_librechat_contract.py
+++ b/tests/unit/test_librechat_contract.py
@@ -1,0 +1,323 @@
+"""Tests for the LibreChat 0.8.5 wire contract.
+
+LibreChat (``@librechat/agents`` >= 3.1.74 + packages/api auth refactor) shipped
+a contract revision where:
+
+  - upload/list responses must carry ``storage_session_id`` (renamed from
+    ``session_id``); we dual-emit both for back-compat.
+  - request/response file references gain ``resource_id``, ``kind``,
+    ``version`` discriminator fields (``CodeEnvFile`` type).
+  - request file refs accept both ``storage_session_id`` (preferred) and
+    ``session_id`` (legacy) via Pydantic ``AliasChoices``.
+  - ``POST /upload/batch`` exists for skill priming and accepts ``kind``,
+    ``id``, ``version``, ``read_only`` form fields.
+
+These tests pin those contract points so a future model refactor cannot
+silently regress LibreChat compatibility again.
+"""
+
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.api.files import list_files, upload_file, upload_files_batch
+from src.models.exec import FileRef, RequestFile
+
+# ---------------------------------------------------------------------------
+# Model alias / computed-field contract
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFileAliases:
+    """RequestFile must accept LibreChat's ``storage_session_id`` field name."""
+
+    def test_accepts_storage_session_id(self):
+        rf = RequestFile(id="f", storage_session_id="sess-A", name="x.csv")
+        assert rf.session_id == "sess-A"
+
+    def test_accepts_legacy_session_id(self):
+        rf = RequestFile(id="f", session_id="sess-A", name="x.csv")
+        assert rf.session_id == "sess-A"
+
+    def test_storage_session_id_wins_when_both_provided(self):
+        """When both names are present, the preferred (LC 0.8.5) wins."""
+        rf = RequestFile.model_validate({"id": "f", "session_id": "old", "storage_session_id": "new", "name": "x"})
+        assert rf.session_id == "new"
+
+    def test_resource_id_kind_version_optional(self):
+        rf = RequestFile(id="f", session_id="s", name="x")
+        assert rf.resource_id is None
+        assert rf.kind is None
+        assert rf.version is None
+
+    def test_resource_id_kind_version_set(self):
+        rf = RequestFile(
+            id="f",
+            storage_session_id="s",
+            name="x",
+            resource_id="r1",
+            kind="skill",
+            version=3,
+        )
+        assert rf.resource_id == "r1"
+        assert rf.kind == "skill"
+        assert rf.version == 3
+
+
+class TestFileRefStorageSessionId:
+    """FileRef must emit ``storage_session_id`` (computed alias of session_id)."""
+
+    def test_storage_session_id_mirrors_session_id(self):
+        ref = FileRef(id="f", name="out.png", session_id="sess-A")
+        dumped = ref.model_dump()
+        assert dumped["storage_session_id"] == "sess-A"
+        assert dumped["session_id"] == "sess-A"
+
+    def test_storage_session_id_none_when_session_id_none(self):
+        ref = FileRef(id="f", name="out.png")
+        dumped = ref.model_dump()
+        assert dumped["storage_session_id"] is None
+        assert dumped["session_id"] is None
+
+    def test_resource_id_kind_version_round_trip(self):
+        ref = FileRef(
+            id="f",
+            name="out.png",
+            session_id="sess-A",
+            resource_id="r1",
+            kind="skill",
+            version=2,
+        )
+        dumped = ref.model_dump()
+        assert dumped["resource_id"] == "r1"
+        assert dumped["kind"] == "skill"
+        assert dumped["version"] == 2
+
+    def test_resource_id_kind_version_excluded_when_none(self):
+        ref = FileRef(id="f", name="out.png", session_id="sess-A")
+        dumped = ref.model_dump(exclude_none=True)
+        assert "resource_id" not in dumped
+        assert "kind" not in dumped
+        assert "version" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# Endpoint contract — /upload, /upload/batch, /files/{session_id}
+# ---------------------------------------------------------------------------
+
+
+def _mock_session(session_id: str = "new-session"):
+    session = MagicMock()
+    session.session_id = session_id
+    return session
+
+
+def _mock_file(filename: str = "f.csv", content: bytes = b"x"):
+    f = MagicMock()
+    f.filename = filename
+    f.content_type = "text/csv"
+    f.size = len(content)
+    f.read = AsyncMock(return_value=content)
+    return f
+
+
+class TestUploadResponseShape:
+    @pytest.mark.asyncio
+    async def test_upload_emits_storage_session_id(self):
+        session_service = MagicMock()
+        session_service.list_sessions_by_entity = AsyncMock(return_value=[])
+        session_service.create_session = AsyncMock(return_value=_mock_session("sess-1"))
+
+        file_service = MagicMock()
+        file_service.store_uploaded_file = AsyncMock(return_value="fid-1")
+
+        result = await upload_file(
+            file=_mock_file(),
+            files=None,
+            entity_id=None,
+            user_id_header=None,
+            x_user_id_header=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert result["storage_session_id"] == "sess-1"
+        # Dual-emit: session_id still present for back-compat.
+        assert result["session_id"] == "sess-1"
+        assert result["files"][0]["fileId"] == "fid-1"
+
+
+class TestUploadBatchEndpoint:
+    @pytest.mark.asyncio
+    async def test_batch_returns_storage_session_id_and_counts(self):
+        session_service = MagicMock()
+        session_service.list_sessions_by_entity = AsyncMock(return_value=[])
+        session_service.create_session = AsyncMock(return_value=_mock_session("sess-b"))
+
+        file_service = MagicMock()
+        file_service.store_uploaded_file = AsyncMock(side_effect=["fid-a", "fid-b"])
+
+        files = [_mock_file("a.csv", b"a"), _mock_file("b.csv", b"b")]
+
+        result = await upload_files_batch(
+            file=files,
+            files=None,
+            entity_id=None,
+            kind="skill",
+            id="skill-123",
+            version="3",
+            read_only="true",
+            user_id_header=None,
+            x_user_id_header=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert result["storage_session_id"] == "sess-b"
+        assert result["session_id"] == "sess-b"
+        assert result["succeeded"] == 2
+        assert result["failed"] == 0
+        assert {f["fileId"] for f in result["files"]} == {"fid-a", "fid-b"}
+
+    @pytest.mark.asyncio
+    async def test_batch_kind_skill_persists_on_session_metadata(self):
+        """``kind`` / ``id`` form fields land on session.metadata so the
+        session can later be filtered by skill/resource."""
+        from src.models.session import SessionCreate
+
+        session_service = MagicMock()
+        session_service.list_sessions_by_entity = AsyncMock(return_value=[])
+        session_service.create_session = AsyncMock(return_value=_mock_session("sess-b"))
+
+        file_service = MagicMock()
+        file_service.store_uploaded_file = AsyncMock(return_value="fid-a")
+
+        await upload_files_batch(
+            file=[_mock_file("a.toml", b"[tool]")],
+            files=None,
+            entity_id=None,
+            kind="skill",
+            id="skill-123",
+            version="2",
+            read_only="true",
+            user_id_header="user-A",
+            x_user_id_header=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        call = session_service.create_session.call_args
+        sc: SessionCreate = call.args[0]
+        assert sc.metadata.get("kind") == "skill"
+        assert sc.metadata.get("resource_id") == "skill-123"
+        assert sc.metadata.get("user_id") == "user-A"
+
+    @pytest.mark.asyncio
+    async def test_batch_per_file_failure_does_not_abort_batch(self):
+        """One file failing must not torpedo the whole batch — succeeded
+        files still get committed, failed ones surface in `failed`."""
+        session_service = MagicMock()
+        session_service.list_sessions_by_entity = AsyncMock(return_value=[])
+        session_service.create_session = AsyncMock(return_value=_mock_session("sess-b"))
+
+        file_service = MagicMock()
+        file_service.store_uploaded_file = AsyncMock(side_effect=["fid-a", Exception("MinIO down"), "fid-c"])
+
+        result = await upload_files_batch(
+            file=[
+                _mock_file("a.csv", b"a"),
+                _mock_file("b.csv", b"b"),
+                _mock_file("c.csv", b"c"),
+            ],
+            files=None,
+            entity_id=None,
+            kind=None,
+            id=None,
+            version=None,
+            read_only=None,
+            user_id_header=None,
+            x_user_id_header=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert result["succeeded"] == 2
+        assert result["failed"] == 1
+        statuses = [f["status"] for f in result["files"]]
+        assert statuses == ["success", "error", "success"]
+
+    @pytest.mark.asyncio
+    async def test_batch_empty_returns_422(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            await upload_files_batch(
+                file=None,
+                files=None,
+                entity_id=None,
+                kind=None,
+                id=None,
+                version=None,
+                read_only=None,
+                user_id_header=None,
+                x_user_id_header=None,
+                file_service=MagicMock(),
+                session_service=MagicMock(),
+            )
+        assert exc.value.status_code == 422
+
+
+class TestListFilesContract:
+    @pytest.mark.asyncio
+    async def test_list_files_accepts_kind_id_version_query_params(self):
+        """The kind/id/version params are pass-through (no server-side
+        filtering today) but MUST be accepted so LC's fetchSessionFiles
+        does not 422."""
+        file_service = MagicMock()
+        file_service.list_files = AsyncMock(return_value=[])
+        session_service = MagicMock()
+
+        # No exception, returns empty list cleanly.
+        result = await list_files(
+            session_id="sess-1",
+            detail=None,
+            kind="skill",
+            id="skill-123",
+            version=2,
+            file_service=file_service,
+            session_service=session_service,
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_files_detail_full_emits_storage_session_id(self):
+        from datetime import datetime
+
+        from src.models.files import FileInfo
+
+        info = FileInfo(
+            file_id="fid",
+            filename="data.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/data.csv",
+        )
+        file_service = MagicMock()
+        file_service.list_files = AsyncMock(return_value=[info])
+        session_service = MagicMock()
+
+        result = await list_files(
+            session_id="sess-1",
+            detail=None,
+            kind=None,
+            id=None,
+            version=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert len(result) == 1
+        assert result[0]["storage_session_id"] == "sess-1"
+        assert result[0]["session_id"] == "sess-1"

--- a/tests/unit/test_librechat_contract.py
+++ b/tests/unit/test_librechat_contract.py
@@ -122,6 +122,20 @@ def _mock_file(filename: str = "f.csv", content: bytes = b"x"):
     return f
 
 
+def _anon_http_request():
+    """Anonymous HTTP request (no JWT-resolved user_id).
+
+    upload_file/upload_files_batch read ``request.state.user_id`` first
+    (set by SecurityMiddleware when JWT auth is enabled). Contract tests
+    don't exercise that path; explicit None forces resolution to fall
+    through to the User-Id / X-User-Id headers as before.
+    """
+    request = MagicMock()
+    request.state = MagicMock()
+    request.state.user_id = None
+    return request
+
+
 class TestUploadResponseShape:
     @pytest.mark.asyncio
     async def test_upload_emits_storage_session_id(self):
@@ -133,6 +147,7 @@ class TestUploadResponseShape:
         file_service.store_uploaded_file = AsyncMock(return_value="fid-1")
 
         result = await upload_file(
+            request=_anon_http_request(),
             file=_mock_file(),
             files=None,
             entity_id=None,
@@ -161,6 +176,7 @@ class TestUploadBatchEndpoint:
         files = [_mock_file("a.csv", b"a"), _mock_file("b.csv", b"b")]
 
         result = await upload_files_batch(
+            request=_anon_http_request(),
             file=files,
             files=None,
             entity_id=None,
@@ -194,6 +210,7 @@ class TestUploadBatchEndpoint:
         file_service.store_uploaded_file = AsyncMock(return_value="fid-a")
 
         await upload_files_batch(
+            request=_anon_http_request(),
             file=[_mock_file("a.toml", b"[tool]")],
             files=None,
             entity_id=None,
@@ -225,6 +242,7 @@ class TestUploadBatchEndpoint:
         file_service.store_uploaded_file = AsyncMock(side_effect=["fid-a", Exception("MinIO down"), "fid-c"])
 
         result = await upload_files_batch(
+            request=_anon_http_request(),
             file=[
                 _mock_file("a.csv", b"a"),
                 _mock_file("b.csv", b"b"),
@@ -253,6 +271,7 @@ class TestUploadBatchEndpoint:
 
         with pytest.raises(HTTPException) as exc:
             await upload_files_batch(
+                request=_anon_http_request(),
                 file=None,
                 files=None,
                 entity_id=None,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1303,9 +1303,7 @@ class TestSessionIsolation:
         )
 
     @pytest.mark.asyncio
-    async def test_file_ref_session_NOT_reused_for_different_user(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_file_ref_session_NOT_reused_for_different_user(self, orchestrator, mock_session_service):
         """Attacker user-B references file_ref.session_id from user-A's session.
         Must NOT reuse — must create a fresh session for user-B.
         """
@@ -1330,9 +1328,7 @@ class TestSessionIsolation:
         mock_session_service.create_session.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_file_ref_session_NOT_reused_when_request_has_no_user_id(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_file_ref_session_NOT_reused_when_request_has_no_user_id(self, orchestrator, mock_session_service):
         """Even when the upload session has no user_id, a request without
         user_id must NOT inherit it — we can't prove ownership."""
         from src.models.exec import RequestFile
@@ -1355,9 +1351,7 @@ class TestSessionIsolation:
         mock_session_service.create_session.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_file_ref_session_reused_for_same_user(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_file_ref_session_reused_for_same_user(self, orchestrator, mock_session_service):
         """Same user uploads a file then references it in /exec — reuse OK."""
         from src.models.exec import RequestFile
 
@@ -1378,9 +1372,7 @@ class TestSessionIsolation:
         mock_session_service.create_session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_entity_id_session_NOT_reused_for_different_user(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_entity_id_session_NOT_reused_for_different_user(self, orchestrator, mock_session_service):
         """Shared agent with entity_id: user-B must NOT reuse user-A's session."""
         a_session = self._session("entity-by-A", user_id="user-A", entity_id="agent-X")
         b_session = self._session("new-for-B", user_id="user-B", entity_id="agent-X")
@@ -1401,9 +1393,7 @@ class TestSessionIsolation:
         assert session_id == "new-for-B"
 
     @pytest.mark.asyncio
-    async def test_entity_id_session_picks_users_own_among_many(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_entity_id_session_picks_users_own_among_many(self, orchestrator, mock_session_service):
         """Entity has multiple users' sessions; pick the requesting user's,
         not just the first."""
         sessions = [
@@ -1427,9 +1417,7 @@ class TestSessionIsolation:
         assert session_id == "entity-by-B"
 
     @pytest.mark.asyncio
-    async def test_explicit_session_id_in_request_always_reused(
-        self, orchestrator, mock_session_service
-    ):
+    async def test_explicit_session_id_in_request_always_reused(self, orchestrator, mock_session_service):
         """request.session_id is opaque; if the auth layer let the request
         through, we trust the user knows their session. (Don't break stateful
         Python continuation with surprise ownership checks.)"""
@@ -1449,9 +1437,7 @@ class TestSessionIsolation:
         assert session_id == "explicit-sid"
 
     @pytest.mark.asyncio
-    async def test_mount_files_skips_foreign_user_session(
-        self, orchestrator, mock_session_service, mock_file_service
-    ):
+    async def test_mount_files_skips_foreign_user_session(self, orchestrator, mock_session_service, mock_file_service):
         """Defense in depth: even if a fresh execution session is created
         (per _get_or_create_session security check), _mount_files must refuse
         to copy file contents out of a session owned by a different user."""

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -193,11 +193,19 @@ class TestGetOrCreateSession:
 
     @pytest.mark.asyncio
     async def test_reuse_session_by_entity_id(self, orchestrator, mock_session_service, sample_session):
-        """Test reusing session by entity_id."""
+        """Test reusing session by entity_id (same user only).
+
+        Sessions referenced via entity_id can leak between users of a shared
+        agent, so reuse requires matching user_id. Verifies the same-user
+        happy path here; the cross-user denial is covered in
+        TestSessionIsolation.
+        """
+        sample_session.metadata = {"user_id": "user-1", "entity_id": "entity-123"}
         request = ExecRequest(
             code="print('hello')",
             lang="python",
             entity_id="entity-123",
+            user_id="user-1",
         )
         mock_session_service.get_session.return_value = None
         mock_session_service.list_sessions_by_entity.return_value = [sample_session]
@@ -309,13 +317,20 @@ class TestGetOrCreateSessionExtended:
 
     @pytest.mark.asyncio
     async def test_session_from_file_ref(self, orchestrator, mock_session_service, sample_session):
-        """Test reusing session from file reference."""
+        """Test reusing session from file reference (same user only).
+
+        Same-user file_ref reuse is the legitimate session-continuity path
+        (upload-then-exec for the same user). Cross-user denial is covered
+        in TestSessionIsolation.
+        """
         from src.models.exec import RequestFile
 
+        sample_session.metadata = {"user_id": "user-1"}
         request_file = RequestFile(id="file-123", session_id="session-123", name="test.txt")
         request = ExecRequest(
             code="print('hello')",
             lang="python",
+            user_id="user-1",
             files=[request_file],
         )
         mock_session_service.get_session.return_value = sample_session
@@ -490,7 +505,7 @@ class TestMountFilesExtended:
 
         request_file = RequestFile(id="file-123", session_id="session-123", name="test.txt")
         request = ExecRequest(code="print('hello')", lang="python", files=[request_file])
-        ctx = ExecutionContext(request=request, request_id="req-123")
+        ctx = ExecutionContext(request=request, request_id="req-123", session_id="session-123")
 
         result = await orchestrator._mount_files(ctx)
 
@@ -537,7 +552,7 @@ class TestMountFilesExtended:
 
         request_file = RequestFile(id="file-123", session_id="session-123", name="test.txt")
         request = ExecRequest(code="print('hello')", lang="python", files=[request_file])
-        ctx = ExecutionContext(request=request, request_id="req-123")
+        ctx = ExecutionContext(request=request, request_id="req-123", session_id="session-123")
 
         result = await orchestrator._mount_files(ctx)
 
@@ -569,7 +584,7 @@ class TestMountFilesExtended:
             lang="python",
             files=[request_file, request_file],  # Duplicate
         )
-        ctx = ExecutionContext(request=request, request_id="req-123")
+        ctx = ExecutionContext(request=request, request_id="req-123", session_id="session-123")
 
         result = await orchestrator._mount_files(ctx)
 
@@ -1256,3 +1271,309 @@ class TestCleanupExtended:
 
         # Give the background task a chance to run
         await asyncio.sleep(0.1)
+
+
+class TestSessionIsolation:
+    """Tests for cross-user session isolation in _get_or_create_session and _mount_files.
+
+    Background: file references carry a session_id that points to the
+    *storage* session where the file was uploaded. When an agent is shared,
+    all users see file references pointing at the same upload session. Blindly
+    reusing that session for execution leaks state/files across users.
+
+    These tests pin down the same-user/cross-user matrix for every session
+    lookup path.
+    """
+
+    @staticmethod
+    def _session(session_id: str, *, user_id: str | None = None, entity_id: str | None = None):
+        from datetime import timedelta
+
+        metadata: dict = {}
+        if user_id is not None:
+            metadata["user_id"] = user_id
+        if entity_id is not None:
+            metadata["entity_id"] = entity_id
+        return Session(
+            session_id=session_id,
+            status=SessionStatus.ACTIVE,
+            created_at=datetime.now(),
+            expires_at=datetime.now() + timedelta(hours=1),
+            metadata=metadata,
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_ref_session_NOT_reused_for_different_user(
+        self, orchestrator, mock_session_service
+    ):
+        """Attacker user-B references file_ref.session_id from user-A's session.
+        Must NOT reuse — must create a fresh session for user-B.
+        """
+        from src.models.exec import RequestFile
+
+        upload_session = self._session("upload-by-A", user_id="user-A")
+        new_session = self._session("new-for-B", user_id="user-B")
+        mock_session_service.get_session.return_value = upload_session
+        mock_session_service.create_session.return_value = new_session
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-B",
+            files=[RequestFile(id="fid", session_id="upload-by-A", name="leak.csv")],
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "new-for-B"
+        mock_session_service.create_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_file_ref_session_NOT_reused_when_request_has_no_user_id(
+        self, orchestrator, mock_session_service
+    ):
+        """Even when the upload session has no user_id, a request without
+        user_id must NOT inherit it — we can't prove ownership."""
+        from src.models.exec import RequestFile
+
+        upload_session = self._session("upload-anon")
+        new_session = self._session("new-anon")
+        mock_session_service.get_session.return_value = upload_session
+        mock_session_service.create_session.return_value = new_session
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            files=[RequestFile(id="fid", session_id="upload-anon", name="x.txt")],
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "new-anon"
+        mock_session_service.create_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_file_ref_session_reused_for_same_user(
+        self, orchestrator, mock_session_service
+    ):
+        """Same user uploads a file then references it in /exec — reuse OK."""
+        from src.models.exec import RequestFile
+
+        upload_session = self._session("upload-by-A", user_id="user-A")
+        mock_session_service.get_session.return_value = upload_session
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-A",
+            files=[RequestFile(id="fid", session_id="upload-by-A", name="own.csv")],
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "upload-by-A"
+        mock_session_service.create_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entity_id_session_NOT_reused_for_different_user(
+        self, orchestrator, mock_session_service
+    ):
+        """Shared agent with entity_id: user-B must NOT reuse user-A's session."""
+        a_session = self._session("entity-by-A", user_id="user-A", entity_id="agent-X")
+        b_session = self._session("new-for-B", user_id="user-B", entity_id="agent-X")
+        mock_session_service.get_session.return_value = None
+        mock_session_service.list_sessions_by_entity.return_value = [a_session]
+        mock_session_service.create_session.return_value = b_session
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-B",
+            entity_id="agent-X",
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "new-for-B"
+
+    @pytest.mark.asyncio
+    async def test_entity_id_session_picks_users_own_among_many(
+        self, orchestrator, mock_session_service
+    ):
+        """Entity has multiple users' sessions; pick the requesting user's,
+        not just the first."""
+        sessions = [
+            self._session("entity-by-A", user_id="user-A", entity_id="agent-X"),
+            self._session("entity-by-B", user_id="user-B", entity_id="agent-X"),
+            self._session("entity-by-C", user_id="user-C", entity_id="agent-X"),
+        ]
+        mock_session_service.get_session.return_value = None
+        mock_session_service.list_sessions_by_entity.return_value = sessions
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-B",
+            entity_id="agent-X",
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "entity-by-B"
+
+    @pytest.mark.asyncio
+    async def test_explicit_session_id_in_request_always_reused(
+        self, orchestrator, mock_session_service
+    ):
+        """request.session_id is opaque; if the auth layer let the request
+        through, we trust the user knows their session. (Don't break stateful
+        Python continuation with surprise ownership checks.)"""
+        existing = self._session("explicit-sid", user_id="user-Z")
+        mock_session_service.get_session.return_value = existing
+
+        request = ExecRequest(
+            code="x = 1",
+            lang="py",
+            session_id="explicit-sid",
+            user_id="someone-else",
+        )
+        ctx = ExecutionContext(request=request, request_id="req")
+
+        session_id = await orchestrator._get_or_create_session(ctx)
+
+        assert session_id == "explicit-sid"
+
+    @pytest.mark.asyncio
+    async def test_mount_files_skips_foreign_user_session(
+        self, orchestrator, mock_session_service, mock_file_service
+    ):
+        """Defense in depth: even if a fresh execution session is created
+        (per _get_or_create_session security check), _mount_files must refuse
+        to copy file contents out of a session owned by a different user."""
+        from src.models.exec import RequestFile
+        from src.models.files import FileInfo
+
+        # Foreign session (owned by user-A) referenced by user-B's request.
+        foreign_session = self._session("upload-by-A", user_id="user-A")
+        mock_session_service.get_session.return_value = foreign_session
+
+        # File service would otherwise happily return content for the file.
+        foreign_file = FileInfo(
+            file_id="fid",
+            filename="secret.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/secret.csv",
+        )
+        mock_file_service.get_file_info.return_value = foreign_file
+        mock_file_service.list_files.return_value = []
+        mock_file_service.get_file_content = AsyncMock(return_value=b"SECRET")
+        mock_file_service.store_uploaded_file = AsyncMock()
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-B",
+            files=[RequestFile(id="fid", session_id="upload-by-A", name="secret.csv")],
+        )
+        ctx = ExecutionContext(
+            request=request,
+            request_id="req",
+            session_id="fresh-for-B",
+        )
+
+        mounted = await orchestrator._mount_files(ctx)
+
+        assert mounted == [], "foreign file content must not leak into user-B's pod"
+        mock_file_service.get_file_content.assert_not_called()
+        mock_file_service.store_uploaded_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mount_files_allows_same_user_cross_session(
+        self, orchestrator, mock_session_service, mock_file_service
+    ):
+        """Same user can still reference files from a previous session of
+        theirs (legitimate continuity)."""
+        from src.models.exec import RequestFile
+        from src.models.files import FileInfo
+
+        own_session = self._session("upload-by-A", user_id="user-A")
+        mock_session_service.get_session.return_value = own_session
+
+        own_file = FileInfo(
+            file_id="fid",
+            filename="mine.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/mine.csv",
+        )
+        mock_file_service.get_file_info.return_value = own_file
+        mock_file_service.list_files.return_value = []
+        mock_file_service.get_file_content = AsyncMock(return_value=b"data")
+        mock_file_service.store_uploaded_file = AsyncMock(return_value="new-id")
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-A",
+            files=[RequestFile(id="fid", session_id="upload-by-A", name="mine.csv")],
+        )
+        ctx = ExecutionContext(
+            request=request,
+            request_id="req",
+            session_id="exec-for-A",
+        )
+
+        mounted = await orchestrator._mount_files(ctx)
+
+        assert len(mounted) == 1
+        assert mounted[0]["filename"] == "mine.csv"
+
+    @pytest.mark.asyncio
+    async def test_mount_files_allows_legacy_anonymous_session(
+        self, orchestrator, mock_session_service, mock_file_service
+    ):
+        """Sessions created before user_id was tracked carry no metadata.
+        We allow these for backward compat (the leak window predates the
+        ownership concept; no further-leakage is created)."""
+        from src.models.exec import RequestFile
+        from src.models.files import FileInfo
+
+        legacy_session = self._session("legacy-upload")  # no user_id metadata
+        mock_session_service.get_session.return_value = legacy_session
+
+        info = FileInfo(
+            file_id="fid",
+            filename="old.csv",
+            size=10,
+            content_type="text/csv",
+            created_at=datetime.now(),
+            path="/old.csv",
+        )
+        mock_file_service.get_file_info.return_value = info
+        mock_file_service.list_files.return_value = []
+        mock_file_service.get_file_content = AsyncMock(return_value=b"old")
+        mock_file_service.store_uploaded_file = AsyncMock(return_value="new-id")
+
+        request = ExecRequest(
+            code="print('hi')",
+            lang="py",
+            user_id="user-A",
+            files=[RequestFile(id="fid", session_id="legacy-upload", name="old.csv")],
+        )
+        ctx = ExecutionContext(
+            request=request,
+            request_id="req",
+            session_id="exec-for-A",
+        )
+
+        mounted = await orchestrator._mount_files(ctx)
+
+        assert len(mounted) == 1

--- a/tests/unit/test_security_middleware.py
+++ b/tests/unit/test_security_middleware.py
@@ -750,9 +750,7 @@ class TestAuthenticateJwt:
         from src.services.codeapi_jwt import JwtClaims
 
         scope: dict = {}
-        claims = JwtClaims(
-            sub="u", tenant_id="t", role=None, principal_source=None, jti=None
-        )
+        claims = JwtClaims(sub="u", tenant_id="t", role=None, principal_source=None, jti=None)
 
         with _patch("src.services.codeapi_jwt.verify", return_value=claims):
             with _patch("src.middleware.security.settings") as mock_settings:
@@ -796,9 +794,7 @@ class TestJwtTakesPrecedenceOverApiKey:
     fall back to API-key auth (downgrade-attack defence)."""
 
     @pytest.mark.asyncio
-    async def test_failed_jwt_does_not_fall_back_to_api_key(
-        self, security_middleware, mock_app, mock_send
-    ):
+    async def test_failed_jwt_does_not_fall_back_to_api_key(self, security_middleware, mock_app, mock_send):
         """End-to-end through __call__: bad JWT must 401, NEVER reach the
         API-key auth path with the same Bearer string."""
         import json as _json

--- a/tests/unit/test_security_middleware.py
+++ b/tests/unit/test_security_middleware.py
@@ -668,3 +668,177 @@ class TestAuthEnabledBypass:
             assert security_middleware._should_skip_auth(request, scope) is True
 
         assert scope["state"]["api_key_hash"] == "anonymous"
+
+
+class TestExtractBearerJwt:
+    """``_extract_bearer_jwt`` is the gate: it returns a token only when
+    ``settings.codeapi_jwt_enabled`` AND the Bearer value looks like a JWT.
+    Everything else falls through to the API-key path."""
+
+    def test_returns_none_when_jwt_disabled(self, security_middleware):
+        request = MagicMock()
+        request.headers.get.return_value = "Bearer aaaa.bbbb.cccc"
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = False
+            assert security_middleware._extract_bearer_jwt(request) is None
+
+    def test_returns_none_without_bearer_scheme(self, security_middleware):
+        request = MagicMock()
+        request.headers.get.return_value = "Basic ZG9lOnNlY3JldA=="
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            assert security_middleware._extract_bearer_jwt(request) is None
+
+    def test_returns_none_when_bearer_is_not_jwt_shaped(self, security_middleware):
+        """A plain API key submitted as Bearer must NOT be classified as JWT
+        (otherwise we'd 401 every legacy ApiKey-via-Bearer client)."""
+        request = MagicMock()
+        request.headers.get.return_value = "Bearer my-flat-api-key-deadbeef"
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            assert security_middleware._extract_bearer_jwt(request) is None
+
+    def test_returns_token_when_jwt_enabled_and_shaped(self, security_middleware):
+        request = MagicMock()
+        request.headers.get.return_value = "Bearer aaaa.bbbb.cccc"
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            assert security_middleware._extract_bearer_jwt(request) == "aaaa.bbbb.cccc"
+
+
+class TestAuthenticateJwt:
+    """``_authenticate_jwt`` calls the verifier and seeds scope state."""
+
+    @pytest.mark.asyncio
+    async def test_valid_jwt_seeds_user_id_and_auth_state(self, security_middleware):
+        from unittest.mock import patch as _patch
+
+        from src.services.codeapi_jwt import JwtClaims
+
+        scope: dict = {}
+        claims = JwtClaims(
+            sub="user-from-jwt",
+            tenant_id="tenant-A",
+            role="USER",
+            principal_source="librechat_jwt",
+            jti="jti-1",
+        )
+
+        with _patch("src.services.codeapi_jwt.verify", return_value=claims):
+            with _patch("src.middleware.security.settings") as mock_settings:
+                mock_settings.codeapi_jwt_trust_tenant_id = True
+                await security_middleware._authenticate_jwt("a.b.c", scope)
+
+        state = scope["state"]
+        assert state["authenticated"] is True
+        assert state["user_id"] == "user-from-jwt"
+        assert state["api_key"] == ""  # not an api-key path
+        assert state["api_key_hash"].startswith("jwt:")
+        assert state["is_env_key"] is False
+        assert state["auth_principal_source"] == "codeapi_jwt"
+        assert state["tenant_id"] == "tenant-A"
+        assert state["jwt_jti"] == "jti-1"
+
+    @pytest.mark.asyncio
+    async def test_tenant_id_omitted_when_trust_disabled(self, security_middleware):
+        from unittest.mock import patch as _patch
+
+        from src.services.codeapi_jwt import JwtClaims
+
+        scope: dict = {}
+        claims = JwtClaims(
+            sub="u", tenant_id="t", role=None, principal_source=None, jti=None
+        )
+
+        with _patch("src.services.codeapi_jwt.verify", return_value=claims):
+            with _patch("src.middleware.security.settings") as mock_settings:
+                mock_settings.codeapi_jwt_trust_tenant_id = False
+                await security_middleware._authenticate_jwt("a.b.c", scope)
+
+        assert "tenant_id" not in scope["state"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_jwt_raises_401(self, security_middleware):
+        from unittest.mock import patch as _patch
+
+        from src.services.codeapi_jwt import CodeApiJwtError
+
+        with _patch("src.services.codeapi_jwt.verify", side_effect=CodeApiJwtError("expired")):
+            with pytest.raises(HTTPException) as exc:
+                await security_middleware._authenticate_jwt("a.b.c", {})
+        assert exc.value.status_code == 401
+        assert "expired" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_misconfigured_jwt_raises_500(self, security_middleware):
+        """Operator enabled JWT auth but didn't configure a public key.
+        Client did nothing wrong; 500 is correct."""
+        from unittest.mock import patch as _patch
+
+        from src.services.codeapi_jwt import CodeApiJwtConfigurationError
+
+        with _patch(
+            "src.services.codeapi_jwt.verify",
+            side_effect=CodeApiJwtConfigurationError("no key"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await security_middleware._authenticate_jwt("a.b.c", {})
+        assert exc.value.status_code == 500
+
+
+class TestJwtTakesPrecedenceOverApiKey:
+    """When a JWT-shaped Bearer is present AND JWT auth is enabled, the
+    JWT path runs INSTEAD OF the API-key path. A failed JWT must NOT
+    fall back to API-key auth (downgrade-attack defence)."""
+
+    @pytest.mark.asyncio
+    async def test_failed_jwt_does_not_fall_back_to_api_key(
+        self, security_middleware, mock_app, mock_send
+    ):
+        """End-to-end through __call__: bad JWT must 401, NEVER reach the
+        API-key auth path with the same Bearer string."""
+        import json as _json
+        from unittest.mock import patch as _patch
+
+        from src.services.codeapi_jwt import CodeApiJwtError
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/exec",
+            "query_string": b"",
+            "headers": [
+                (b"authorization", b"Bearer aaaa.bbbb.cccc"),
+                (b"content-type", b"application/json"),
+            ],
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        with _patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.codeapi_jwt_enabled = True
+            mock_settings.codeapi_jwt_trust_tenant_id = False
+            mock_settings.auth_enabled = True
+            mock_settings.auth_trusted_networks = ""
+            mock_settings.max_file_size_mb = 10
+            with _patch(
+                "src.services.codeapi_jwt.verify",
+                side_effect=CodeApiJwtError("bad signature"),
+            ):
+                await security_middleware(scope, receive, send)
+
+        # Response is a 401; downstream app was NEVER called (no fallback).
+        mock_app.assert_not_called()
+        start = sent[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 401

--- a/tests/unit/test_security_middleware.py
+++ b/tests/unit/test_security_middleware.py
@@ -122,7 +122,7 @@ class TestShouldSkipAuth:
         request.url.path = "/health"
         request.method = "GET"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -132,7 +132,7 @@ class TestShouldSkipAuth:
         request.url.path = "/ready"
         request.method = "GET"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -142,7 +142,7 @@ class TestShouldSkipAuth:
         request.url.path = "/docs"
         request.method = "GET"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -152,7 +152,7 @@ class TestShouldSkipAuth:
         request.url.path = "/api/v1/admin/keys"
         request.method = "GET"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -162,7 +162,7 @@ class TestShouldSkipAuth:
         request.url.path = "/admin-dashboard/metrics"
         request.method = "GET"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -172,7 +172,7 @@ class TestShouldSkipAuth:
         request.url.path = "/api/v1/exec"
         request.method = "OPTIONS"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is True
 
@@ -182,7 +182,7 @@ class TestShouldSkipAuth:
         request.url.path = "/api/v1/exec"
         request.method = "POST"
 
-        result = security_middleware._should_skip_auth(request)
+        result = security_middleware._should_skip_auth(request, {})
 
         assert result is False
 
@@ -504,3 +504,167 @@ class TestRequestLoggingMiddleware:
 
         with pytest.raises(ValueError):
             await logging_middleware(scope, mock_receive, mock_send)
+
+
+class TestExtractApiKeyBasicAuth:
+    """LibreChat 0.8.5 (@librechat/agents >=3.1.74) dropped x-api-key and the
+    body-spread LIBRECHAT_CODE_API_KEY field. The only remaining channel for
+    the legacy LIBRECHAT_CODE_BASEURL=https://KEY@host/v1 pattern is the
+    Basic auth header that axios derives from URL credentials. These tests
+    pin down our handling of that channel.
+    """
+
+    @staticmethod
+    def _request_with_auth(value: str | None):
+        import base64
+
+        request = MagicMock()
+
+        def _get(name, default=None):
+            if name == "x-api-key":
+                return None
+            if name == "authorization":
+                return value if value is not None else default
+            return default
+
+        request.headers.get.side_effect = _get
+        return request
+
+    def _basic(self, raw: str) -> str:
+        import base64
+
+        return "Basic " + base64.b64encode(raw.encode("utf-8")).decode("ascii")
+
+    def test_basic_auth_user_only(self, security_middleware):
+        """axios URL-creds form: ``https://KEY@host`` -> ``Basic base64('KEY:')``.
+        We must return KEY (the user half)."""
+        request = self._request_with_auth(self._basic("test-api-key-12345:"))
+        assert security_middleware._extract_api_key(request) == "test-api-key-12345"
+
+    def test_basic_auth_password_only(self, security_middleware):
+        """``:KEY`` form falls through to password half."""
+        request = self._request_with_auth(self._basic(":test-api-key-12345"))
+        assert security_middleware._extract_api_key(request) == "test-api-key-12345"
+
+    def test_basic_auth_user_and_password_prefers_user(self, security_middleware):
+        """``user:KEY`` is ambiguous; LibreChat uses the user half, so we
+        match upstream and return ``user``. Document the convention so
+        ``user:KEY`` deployments know to flip the values."""
+        request = self._request_with_auth(self._basic("apiuser:apikey"))
+        assert security_middleware._extract_api_key(request) == "apiuser"
+
+    def test_basic_auth_invalid_base64(self, security_middleware):
+        """Malformed Basic header returns None (no crash, no 500)."""
+        request = self._request_with_auth("Basic !!!notbase64!!!")
+        assert security_middleware._extract_api_key(request) is None
+
+    def test_basic_auth_empty(self, security_middleware):
+        """``Basic `` with no value returns None."""
+        request = self._request_with_auth("Basic ")
+        assert security_middleware._extract_api_key(request) is None
+
+    def test_x_api_key_wins_over_basic(self, security_middleware):
+        """When both x-api-key AND Authorization are present, x-api-key wins
+        so reverse-proxy injection has deterministic behaviour."""
+        import base64
+
+        request = MagicMock()
+
+        def _get(name, default=None):
+            if name == "x-api-key":
+                return "from-header"
+            if name == "authorization":
+                return "Basic " + base64.b64encode(b"from-basic:").decode("ascii")
+            return default
+
+        request.headers.get.side_effect = _get
+        assert security_middleware._extract_api_key(request) == "from-header"
+
+    def test_bearer_still_works(self, security_middleware):
+        """Adding Basic must not regress Bearer."""
+        request = self._request_with_auth("Bearer my-jwt")
+        assert security_middleware._extract_api_key(request) == "my-jwt"
+
+    def test_apikey_scheme_still_works(self, security_middleware):
+        """Adding Basic must not regress ApiKey."""
+        request = self._request_with_auth("ApiKey my-key")
+        assert security_middleware._extract_api_key(request) == "my-key"
+
+    def test_unknown_scheme_returns_none(self, security_middleware):
+        """Unknown schemes (Digest, Negotiate) return None."""
+        request = self._request_with_auth("Digest realm=foo")
+        assert security_middleware._extract_api_key(request) is None
+
+
+class TestAuthEnabledBypass:
+    """AUTH_ENABLED=false flips middleware into trust-the-boundary mode for
+    user paths. Admin paths must still require MASTER_API_KEY."""
+
+    def test_user_path_bypassed_when_auth_disabled(self, security_middleware):
+        request = MagicMock()
+        request.url.path = "/exec"
+        request.method = "POST"
+        scope = {}
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.auth_enabled = False
+            mock_settings.auth_trusted_networks = ""
+            mock_settings.max_file_size_mb = 10
+            assert security_middleware._should_skip_auth(request, scope) is True
+
+        # Anonymous state must be seeded so downstream metrics don't crash.
+        assert scope["state"]["authenticated"] is True
+        assert scope["state"]["api_key_hash"] == "anonymous"
+        assert scope["state"]["is_env_key"] is False
+
+    def test_user_path_NOT_bypassed_when_auth_enabled(self, security_middleware):
+        request = MagicMock()
+        request.url.path = "/exec"
+        request.method = "POST"
+        scope: dict = {}
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.auth_enabled = True
+            mock_settings.auth_trusted_networks = ""
+            mock_settings.max_file_size_mb = 10
+            assert security_middleware._should_skip_auth(request, scope) is False
+
+        assert scope == {}, "no state seed when auth still required"
+
+    def test_admin_path_does_not_get_anonymous_seed(self, security_middleware):
+        """Admin paths skip middleware auth (their dependency enforces master
+        key) but must NOT be seeded with anonymous state — a bug in an admin
+        endpoint dependency must fail closed, not silently impersonate
+        anonymous."""
+        request = MagicMock()
+        request.url.path = "/api/v1/admin/keys"
+        request.method = "GET"
+        scope: dict = {}
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.auth_enabled = False  # still skip — admin path
+            mock_settings.auth_trusted_networks = ""
+            mock_settings.max_file_size_mb = 10
+            assert security_middleware._should_skip_auth(request, scope) is True
+
+        assert "state" not in scope, "admin path must not receive anonymous seed"
+
+    def test_trusted_network_seeds_anonymous(self, security_middleware):
+        """Trusted-network bypass also gets the anonymous state seed."""
+        request = MagicMock()
+        request.url.path = "/exec"
+        request.method = "POST"
+        request.client.host = "10.0.0.5"
+        scope: dict = {}
+
+        # Inject a trusted CIDR after construction (constructor read empty).
+        import ipaddress
+
+        security_middleware._trusted_networks = [ipaddress.ip_network("10.0.0.0/8")]
+
+        with patch("src.middleware.security.settings") as mock_settings:
+            mock_settings.auth_enabled = True
+            mock_settings.max_file_size_mb = 10
+            assert security_middleware._should_skip_auth(request, scope) is True
+
+        assert scope["state"]["api_key_hash"] == "anonymous"

--- a/tests/unit/test_trusted_networks.py
+++ b/tests/unit/test_trusted_networks.py
@@ -143,16 +143,19 @@ class TestShouldSkipAuth:
             mw = SecurityMiddleware(mock_app)
 
         request = _make_request(client_ip="10.1.2.3", path="/exec")
-        assert mw._should_skip_auth(request) is True
+        # _should_skip_auth now takes scope so it can seed anonymous state
+        # on bypass paths; pass an empty dict for assertion-only callers.
+        assert mw._should_skip_auth(request, {}) is True
 
     def test_untrusted_ip_requires_auth(self, mock_app):
         with patch("src.middleware.security.settings") as mock_settings:
             mock_settings.max_file_size_mb = 10
             mock_settings.auth_trusted_networks = "10.0.0.0/8"
+            mock_settings.auth_enabled = True
             mw = SecurityMiddleware(mock_app)
 
         request = _make_request(client_ip="203.0.113.1", path="/exec")
-        assert mw._should_skip_auth(request) is False
+        assert mw._should_skip_auth(request, {}) is False
 
     def test_excluded_path_still_skips(self, mock_app):
         with patch("src.middleware.security.settings") as mock_settings:
@@ -161,7 +164,7 @@ class TestShouldSkipAuth:
             mw = SecurityMiddleware(mock_app)
 
         request = _make_request(client_ip="203.0.113.1", path="/health")
-        assert mw._should_skip_auth(request) is True
+        assert mw._should_skip_auth(request, {}) is True
 
 
 class TestAuthMiddlewareTrustedNetworks:

--- a/uv.lock
+++ b/uv.lock
@@ -434,6 +434,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -828,6 +881,7 @@ dependencies = [
     { name = "minio" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -864,6 +918,7 @@ requires-dist = [
     { name = "minio", specifier = ">=7.2.20" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.21" },
@@ -1414,6 +1469,20 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A consolidated fix series targeting three interlocked problems users have hit since LibreChat 0.8.5 / `@librechat/agents` ≥ 3.1.74 shipped:

1. **🚨 Security: cross-user file leakage** — When agents are shared, `file_ref.session_id` and `entity_id` reuse paths converged every user onto the upload session, leaking generated files, auto-rehydrated files, and Python state across users. Now gated on `metadata.user_id` ownership.
2. **🔐 LibreChat 0.8.5 auth (401 reports)** — LC dropped `x-api-key` and the body-spread `LIBRECHAT_CODE_API_KEY` field. URL-credentials (`LIBRECHAT_CODE_BASEURL=https://KEY@host/v1`) now reach us as `Authorization: Basic`, which the middleware was ignoring. Optional full JWT auth (`CODEAPI_AUTH_PROVIDER=librechat-jwt`) is also supported now.
3. **🧰 LC 0.8.5 wire contract drift** — `storage_session_id`, `resource_id`, `kind`, `version`, `/upload/batch`, `kind`/`id`/`version` query params on `/files/{session_id}` — all the fields LC's agents lib actually reads.

Plus one big infra change: **all 13 supported language runtimes are now baked into the bash image** because `@librechat/agents` ≥ 3.1.74 collapsed every code-execution tool into `bash_tool` (so every LC `/exec` arrives as `lang: bash` and the model shells out to `python3`, `node`, `go run`, etc.).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] **Security fix** — cross-user file leak (P0)
- [x] New feature (LC 0.8.5 JWT auth, Basic auth, `AUTH_ENABLED` flag, `/upload/batch`)
- [x] Documentation update

## Commits (10)

| # | Commit | What |
|---|---|---|
| 1 | `fix(security): prevent cross-user file leak via session reuse` | Orchestrator session-lookup gated on `user_id`; defense-in-depth in `_mount_files`. **9 new tests**. |
| 2 | `feat(auth): accept HTTP Basic auth, add AUTH_ENABLED bypass` | `_extract_api_key` now decodes `Basic`; new `AUTH_ENABLED` env var. **11 new tests**. |
| 3 | `feat(api): wire LibreChat User-Id header into session ownership` | `User-Id` / `X-User-Id` → `session.metadata.user_id`. **3 new tests**. |
| 4 | `feat(api): LibreChat 0.8.5 wire contract — storage_session_id, kind, batch` | Models + endpoints; new `POST /upload/batch`. **16 new tests**. |
| 5 | `feat(auth): CodeAPI JWT verifier (LibreChat 0.8.5 signer side)` | New \`src/services/codeapi_jwt.py\`; EdDSA + RS256; alg-confusion defence. **22 new tests**. |
| 6 | `feat(auth): wire CodeAPI JWT verification into SecurityMiddleware` | JWT path takes precedence over Bearer-api-key when it looks like a JWT; failed JWT → 401 (no downgrade). **12 new tests**. |
| 7 | `feat(api): trust JWT.sub over User-Id header in exec + upload` | JWT \`sub\` overrides body / header \`user_id\` — attacker with a valid JWT can't impersonate by lying about user_id. **3 new tests**. |
| 8 | `docs: document AUTH_ENABLED and CODEAPI_JWT_* env vars` | \`.env.example\` + \`docs/CONFIGURATION.md\` |
| 9 | `chore: fmt` | ruff-format pass |
| 10 | `feat(docker): bake every supported language into the bash image` | All 13 runtimes (bash, py + data stack, js, ts, go, java, c, c++, php, rust, r, fortran, d) in \`docker/bash.Dockerfile\`. **13/13 hello-world tests pass.** |

## Auth source priority (highest first)

1. **CodeAPI JWT** — `Authorization: Bearer <jwt>` + `CODEAPI_JWT_ENABLED=true`. Failed JWT returns 401 immediately (no downgrade to api-key).
2. **`x-api-key`** header (legacy).
3. **`Authorization: Bearer <token>` / `ApiKey <token>`** — when the Bearer value is NOT shaped like a JWT.
4. **`Authorization: Basic base64(KEY:)`** — supports `LIBRECHAT_CODE_BASEURL=https://KEY@host/v1`.
5. **JSON body** `LIBRECHAT_CODE_API_KEY` / `api_key` / `apiKey`.

## How Has This Been Tested?

- [x] Full unit suite: `just test-unit` — **1,506 tests pass** (+108 added vs main)
- [x] Lint: `just lint` — clean (ruff)
- [x] Format: `just format-check` — clean
- [x] Types: `just typecheck` — clean (ty)
- [x] Image build: `docker build -f docker/bash.Dockerfile docker/` produces ~865 MB image
- [x] Per-language validation: `./scripts/test-bash-megaimage.sh` runs the runner's exact compile-and-run command for each of 13 languages — **13/13 ok** (bash, python, javascript, typescript, go, java, c, cpp, php, rust, r, fortran, d)

## Security advisory

The cross-user leak (commit 1) is a real security issue in pre-fix versions. **Sessions created before this fix may be cross-user-readable** if your deployment runs shared agents with file uploads. Operators should rotate or purge those sessions after upgrading.

## New configuration

`.env.example` and `docs/CONFIGURATION.md` document these in detail. Quick reference:

\`\`\`bash
# Optional: global auth toggle for trusted-boundary deployments
AUTH_ENABLED=true                         # default
AUTH_TRUSTED_NETWORKS=10.0.0.0/8          # CIDR bypass (unspoofable)

# Optional: LibreChat 0.8.5 JWT (CODEAPI_AUTH_PROVIDER=librechat-jwt)
CODEAPI_JWT_ENABLED=false                 # default
CODEAPI_JWT_PUBLIC_KEY=                   # PEM / JWK JSON / file path
CODEAPI_JWT_ALGORITHM=EdDSA               # or RS256
CODEAPI_JWT_ISSUER=librechat
CODEAPI_JWT_AUDIENCE=codeapi
CODEAPI_JWT_LEEWAY_SECONDS=10
CODEAPI_JWT_TRUST_TENANT_ID=false
\`\`\`

## Backward compatibility

- All existing api-key paths still work; new auth sources are additive.
- `/upload` response keeps `session_id` and adds `storage_session_id` (dual-emit).
- `RequestFile` accepts both `session_id` and `storage_session_id` via Pydantic `AliasChoices`.
- Per-language container images still ship and still serve `/exec` when callers send explicit `lang: <code>` — the unified bash image is for LC's `bash_tool` reality.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Per-language hello-world validation passes (13/13)

## New dependency

`pyjwt[crypto]>=2.10.0` (pulls in `cryptography`) — required for the JWT verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)