### PR TITLE
fix(bash image): full python stack + POD_POOL_<LANG> actually warms replicas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,6 +175,16 @@ POD_POOL_PARALLEL_BATCH=5
 POD_POOL_REPLENISH_INTERVAL=2
 POD_POOL_EXHAUSTION_TRIGGER=true
 
+# Max seconds to wait for a freshly-created pool pod to reach Ready.
+# Default 300s (5 min) accommodates first-pull of large multi-runtime
+# images (the unified bash image is ~1.13 GB and can take 90-180s to
+# pull on a cold node). Too short a timeout is the most common reason
+# `POD_POOL_<LANG>=N` doesn't materialise as N warm replicas — the pool
+# tears down each pod before its image finishes pulling. The pool also
+# early-aborts on terminal states (ImagePullBackOff, CrashLoopBackOff)
+# so a misconfigured image fails fast regardless of this value.
+POD_POOL_READY_TIMEOUT_SECONDS=300
+
 # State Persistence Configuration (Python)
 # Enables Python variable/function persistence across executions within same session
 STATE_PERSISTENCE_ENABLED=true

--- a/docker/bash.Dockerfile
+++ b/docker/bash.Dockerfile
@@ -13,9 +13,14 @@
 # `/exec` when a non-LC caller sends an explicit `lang: <code>`, so
 # direct-API integrations are unaffected.
 #
-# Languages baked in (all 13):
+# Languages baked in:
 #   bash, sh                         — apt: bash + coreutils + jq + grep + sed
-#   python (py) + python data stack  — apt: python3 + python-is-python3 + numpy/pandas/etc.
+#   python (py) + full pip stack     — apt: python3 + python-is-python3
+#                                      pip: docker/requirements/python-*.txt
+#                                      (same lib set as the dedicated python image —
+#                                      xlsxwriter, reportlab, python-docx, python-pptx,
+#                                      pdf2image, mammoth, openpyxl, scikit-learn,
+#                                      scipy, plotly, opencv, numpy, pandas, matplotlib)
 #   javascript (js)                  — apt: nodejs
 #   typescript (ts)                  — npm: typescript globally
 #   go                               — apt: golang-go
@@ -23,13 +28,28 @@
 #   c, cpp                           — apt: gcc, g++
 #   php                              — apt: php-cli
 #   rust (rs)                        — apt: rustc, cargo
-#   r                                — apt: r-base-core
-#   fortran (f90)                    — apt: gfortran
 #   d                                — apt: ldc (uses gcc for linking)
 #
-# Size: ~1.5-2 GB vs ~100 MB for the bash-only image. Trade made deliberately
-# so every LC bash_tool request stays inside the warm pod instead of
-# erroring out on a missing interpreter.
+# Deliberately NOT in the bash image:
+#   fortran (f90)                    — gfortran-14 wants stock
+#                                      gcc-14-base=14.2.0-19 but DHI ships
+#                                      14.2.0-19dhi0 (custom hardened build).
+#                                      Unable to install alongside.
+#   r                                — r-base-core transitively requires
+#                                      liblapack3 → libgfortran5 → same
+#                                      DHI gcc version conflict.
+#
+# Both ARE still served by /exec for explicit `lang: f90` / `lang: r`
+# callers — the dedicated fortran/r per-language images handle those
+# (LC's bash_tool collapse doesn't reach for fortran/r in practice).
+#
+# Size: ~3-4 GB. Big, but unavoidable: LC's bash_tool reaches for
+# python3 -c with any library a python user would use, and a partial
+# python stack means non-deterministic "sometimes works, sometimes
+# ModuleNotFoundError" behaviour (depending on whether the model picked
+# the python image via lang=py or shelled out via lang=bash → python3).
+# Matching the dedicated python image's lib set is the only way to make
+# the two execution paths indistinguishable to the user.
 
 # Global args — must be declared before any FROM so they can interpolate
 # into the FROM lines. They lose scope inside the stages and are re-
@@ -60,19 +80,13 @@ LABEL org.opencontainers.image.title="KubeCodeRun Bash Environment (all language
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Single RUN to keep the layer count low. Order: shell utilities first, then
-# the language families. `apt-get clean` + cache wipe at the end shaves
-# ~50 MB off the final layer.
+# Two-step install: first apt (interpreters/compilers + build deps the
+# pip step may need), then pip (full python stack from the same
+# requirement files the dedicated python image uses, for behaviour
+# parity between `lang=py` and `lang=bash → python3 -c "..."`).
 #
 # python-is-python3 makes `python` resolve to /usr/bin/python3, matching
 # the executor.go Args for the "py" language (which calls `python {file}`).
-#
-# python3-{numpy,pandas,matplotlib,openpyxl,pil} ship the data-analysis
-# stack LLMs typically reach for via `python3 -c` inside bash_tool. Apt
-# is preferred over pip here because (a) layered binary deps make the
-# wheels reliable across base updates, and (b) we don't need bleeding-edge
-# versions for inside-bash one-liners — the dedicated python image still
-# serves `lang: "py"` calls that need pip.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # --- bash + script utilities ---
@@ -84,15 +98,16 @@ RUN apt-get update && \
     findutils \
     jq \
     ca-certificates \
-    # --- python (interpreter + data-analysis stack) ---
+    # --- python (interpreter; lib stack installed via pip below) ---
+    # No apt python3-numpy/pandas/etc. — they pull liblapack3 +
+    # libgfortran5 which can't be installed alongside DHI's custom
+    # gcc-14-base. pip-installed numpy/scipy/etc. bundle their own
+    # openblas in the manylinux wheels so we don't need apt's BLAS.
     python3 \
     python3-pip \
     python-is-python3 \
-    python3-numpy \
-    python3-pandas \
-    python3-matplotlib \
-    python3-openpyxl \
-    python3-pil \
+    # cryptography / lxml etc. wheels dlopen these at runtime.
+    libxml2 libxslt1.1 libffi8 libssl3t64 \
     # --- node.js (js + ts) ---
     nodejs \
     npm \
@@ -103,23 +118,67 @@ RUN apt-get update && \
     # --- c / c++ / linker (used by rust, fortran, d too) ---
     gcc \
     g++ \
+    make \
     # --- php ---
     php-cli \
     # --- rust ---
     rustc \
     cargo \
-    # --- r ---
-    r-base-core \
-    # --- fortran ---
-    gfortran \
     # --- d (ldc compiler) ---
+    # NOTE: r-base-core and gfortran intentionally omitted — they conflict
+    # with DHI's custom gcc-14-base (see comment at top of file). Their
+    # dedicated per-language images still serve explicit `lang=r` / `lang=f90`.
     ldc \
     && npm install -g typescript \
     && npm cache clean --force \
+    # DHI's hardened libzstd1+dhi0 and libffi8+dhi0 can't be dlopen()ed
+    # — Python's _ssl.so (links libzstd) and _ctypes.so (links libffi)
+    # both fail to import with
+    # `ImportError: libX: shared object cannot be dlopen()ed`.
+    # Force-downgrade to stock Debian versions so dlopen works.
+    # --allow-downgrades is required because the DHI versions are held.
+    # Without this fix:
+    #   - pip can't reach PyPI (SSL load fails) → no pip install
+    #   - pandas / numpy / cryptography all fail at runtime (no ctypes)
+    && apt-get install -y --no-install-recommends --allow-downgrades \
+        libzstd1=1.5.7+dfsg-1 \
+        libffi8=3.4.8-2 \
+    && mkdir -p /mnt/data && chown 65532:65532 /mnt/data
+
+# Pip-install the full python lib stack — same requirement files the
+# dedicated python image uses — so `python3 -c` inside bash_tool sees
+# the same modules as a native `lang=py` call. Without this the user
+# experience is "sometimes works, sometimes ModuleNotFoundError"
+# depending on which tool path LC's agent picked.
+#
+# --break-system-packages: Debian's pip is PEP-668-locked; we override
+# because this is a sandbox-builder image, not a user OS install.
+# --no-cache-dir: shave ~500 MB off the final layer.
+#
+# IMPORTANT: pip install MUST happen BEFORE any apt-get autoremove +
+# /var/lib/apt/lists cleanup. The Debian python3-pip package shells out
+# to ca-certificates and a couple of apt-managed lib paths to do SSL
+# verification on its first run; if autoremove fires between the apt
+# RUN and this RUN it strips deps that python3-pip needs at runtime
+# ("SSL module is not available" pip errors). Sequence is: apt install
+# → pip install → apt cleanup, all in this stage.
+COPY requirements/python-core.txt requirements/python-analysis.txt \
+     requirements/python-visualization.txt requirements/python-documents.txt \
+     requirements/python-utilities.txt /tmp/reqs/
+# Skip `pip install --upgrade pip setuptools wheel` — Debian ships them
+# pre-installed without RECORD files so pip refuses to uninstall them
+# ("Cannot uninstall wheel 0.46.1 — no RECORD file"). The apt-installed
+# versions are recent enough for the wheel-only requirement files.
+RUN python3 -m pip install --break-system-packages --no-cache-dir \
+        -r /tmp/reqs/python-core.txt \
+        -r /tmp/reqs/python-analysis.txt \
+        -r /tmp/reqs/python-visualization.txt \
+        -r /tmp/reqs/python-documents.txt \
+        -r /tmp/reqs/python-utilities.txt \
+    && rm -rf /tmp/reqs /root/.cache \
     && apt-get autoremove -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /root/.cache /tmp/* \
-    && mkdir -p /mnt/data && chown 65532:65532 /mnt/data
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 WORKDIR /mnt/data
 

--- a/scripts/test-bash-megaimage.sh
+++ b/scripts/test-bash-megaimage.sh
@@ -22,6 +22,14 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 # `Args` field of each LangSpec in docker/runner/executor.go. {file}
 # resolves to the absolute path of source_filename inside /work, and
 # {wd} resolves to /work.
+#
+# NOTE: r and fortran are deliberately NOT in the bash image because
+# their apt packages (r-base-core, gfortran-14) require liblapack3 /
+# libgfortran5 with stock gcc-14-base, which conflicts with DHI's
+# hardened gcc-14-base+dhi0. The dedicated `lang=r` and `lang=f90`
+# per-language images still serve those callers via /exec. LC's
+# bash_tool collapse doesn't reach for r/fortran in practice, so
+# this trade-off is invisible to the user.
 LANGUAGES=(
     "bash|code.sh|echo 'Hello, World!'|bash {file}"
     "python|code.py|print('Hello, World!')|python {file}"
@@ -33,10 +41,11 @@ LANGUAGES=(
     "cpp|code.cpp|#include <iostream>\nint main() { std::cout << \"Hello, World!\" << std::endl; return 0; }|g++ {file} -o /tmp/code && /tmp/code"
     "php|code.php|<?php echo \"Hello, World!\\\\n\"; ?>|php {file}"
     "rust|main.rs|fn main() { println!(\"Hello, World!\"); }|rustc {file} -o /tmp/main && /tmp/main"
-    "r|code.r|cat('Hello, World!\\\\n')|Rscript {file}"
-    "fortran|code.f90|program hello\n  print *, 'Hello, World!'\nend program hello|gfortran {file} -o /tmp/code && /tmp/code"
     "d|code.d|import std.stdio; void main() { writeln(\"Hello, World!\"); }|ldc2 {file} -of=/tmp/code && /tmp/code"
 )
+
+# Languages intentionally NOT in the bash image (served by dedicated images).
+SKIPPED_LANGUAGES=(r fortran)
 
 EXPECTED="Hello, World!"
 PASS=0
@@ -101,11 +110,16 @@ for entry in "${LANGUAGES[@]}"; do
     fi
 done
 
+for lang in "${SKIPPED_LANGUAGES[@]}"; do
+    echo "↷ $(pad "$lang") skipped (served by dedicated per-language image)"
+done
+
 echo
 echo "─────────────────────────────────────────"
-echo "  Passed: $PASS / $((PASS + FAIL))"
+echo "  Passed:  $PASS / $((PASS + FAIL))"
+echo "  Skipped: ${#SKIPPED_LANGUAGES[@]} (${SKIPPED_LANGUAGES[*]})"
 if [[ $FAIL -gt 0 ]]; then
-    echo "  Failed: ${FAILED_LANGS[*]}"
+    echo "  Failed:  ${FAILED_LANGS[*]}"
     exit 1
 fi
 exit 0

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -332,6 +332,21 @@ class Settings(BaseSettings):
         default=True,
         description="Trigger immediate replenishment when pool is exhausted",
     )
+    pod_pool_ready_timeout_seconds: int = Field(
+        default=300,
+        ge=30,
+        le=1800,
+        description=(
+            "Max seconds to wait for a freshly-created pool pod to reach Ready. "
+            "Default 300s (5 min) accommodates first-pull of large multi-runtime "
+            "images (e.g. the unified bash image is ~1.13 GB and can take 90-180s "
+            "to pull on a cold node). If a pod doesn't go Ready within this "
+            "window, the pool deletes it and tries again — too short a timeout "
+            "in front of a slow image pull is the most common reason a configured "
+            "POD_POOL_<LANG> value never materialises as warm replicas. "
+            "The 30s lower bound prevents accidental misconfig that always fails."
+        ),
+    )
 
     # WAN Network Access Configuration
     # When enabled, execution pods can access the public internet

--- a/src/services/kubernetes/pool.py
+++ b/src/services/kubernetes/pool.py
@@ -382,10 +382,14 @@ class PodPool:
             # Wait for pod to be ready
             ready = await self._wait_for_pod_ready(handle)
             if not ready:
-                logger.warning(
-                    "Warm pod did not become ready, deleting",
+                # _wait_for_pod_ready already logged the detailed failure
+                # reason at ERROR; this is the higher-level rollup so
+                # operators grepping for "pool" find both.
+                logger.error(
+                    "Warm pod failed to ready up — deleting and pool stays short",
                     pod_name=pod_name,
                     language=self.language,
+                    target_pool_size=self.pool_size,
                 )
                 await self._delete_pod(handle)
                 return None
@@ -432,14 +436,45 @@ class PodPool:
     async def _wait_for_pod_ready(
         self,
         handle: PodHandle,
-        timeout: int = 60,
+        timeout: int | None = None,
     ) -> bool:
-        """Wait for a pod to be ready."""
+        """Wait for a pod to be ready.
+
+        Timeout defaults to ``settings.pod_pool_ready_timeout_seconds``
+        (5 min). The previous 60s hardcoded default was too short for the
+        first pull of large multi-runtime images (the unified bash image
+        is ~1.13 GB), causing every configured ``POD_POOL_<LANG>`` to
+        silently materialise as 0 warm replicas because pods were torn
+        down before image pull finished.
+
+        We also early-abort on definitively-broken pod states
+        (ImagePullBackOff, ErrImagePull, CrashLoopBackOff, InvalidImageName)
+        so configuration errors fail fast at ~5s instead of after the
+        whole timeout window.
+        """
+        if timeout is None:
+            from ...config import settings
+
+            timeout = settings.pod_pool_ready_timeout_seconds
+
+        # Container statuses that mean "this pod will never go Ready" —
+        # no point waiting out the full timeout. Mostly image-pull and
+        # crash-loop failures.
+        _terminal_waiting_reasons = {
+            "ImagePullBackOff",
+            "ErrImagePull",
+            "InvalidImageName",
+            "CreateContainerConfigError",
+            "CreateContainerError",
+            "CrashLoopBackOff",
+        }
+
         core_api = get_core_api()
         if not core_api:
             return False
 
         start_time = asyncio.get_event_loop().time()
+        last_reason: str | None = None
 
         while asyncio.get_event_loop().time() - start_time < timeout:
             try:
@@ -463,11 +498,47 @@ class PodPool:
                 elif pod.status.phase in ("Failed", "Succeeded"):
                     return False
 
+                # Early-abort on terminal failures (image-pull, crash-loop).
+                if pod.status and pod.status.container_statuses:
+                    for cs in pod.status.container_statuses:
+                        waiting = getattr(getattr(cs, "state", None), "waiting", None)
+                        reason = getattr(waiting, "reason", None) if waiting else None
+                        if reason:
+                            last_reason = reason
+                            if reason in _terminal_waiting_reasons:
+                                logger.error(
+                                    "Pool pod hit terminal waiting state — aborting wait early",
+                                    pod_name=handle.name,
+                                    language=self.language,
+                                    reason=reason,
+                                    message=getattr(waiting, "message", None),
+                                )
+                                return False
+
             except ApiException:
                 pass
 
             await asyncio.sleep(0.5)
 
+        # Timeout. Log loudly with the last observed waiting reason so an
+        # operator can see at a glance whether to bump the timeout (image
+        # pull was in progress) vs investigate the cluster (probe wedged,
+        # OOM, etc.). Quiet warnings here were the original "I set
+        # POD_POOL_BASH=5 but kubectl shows 0 and nothing in the logs
+        # explains why" report.
+        logger.error(
+            "Pool pod did NOT reach Ready within timeout — pool will stay short",
+            pod_name=handle.name,
+            language=self.language,
+            timeout_seconds=timeout,
+            last_waiting_reason=last_reason,
+            hint=(
+                "If reason is 'ContainerCreating' the image is probably still "
+                "being pulled — raise POD_POOL_READY_TIMEOUT_SECONDS. "
+                "If reason is missing or 'PodInitializing' the runner /ready probe "
+                "may be wedged."
+            ),
+        )
         return False
 
     async def _delete_pod(self, handle: PodHandle):

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -523,6 +523,111 @@ class TestPodPoolWaitForPodReady:
 
         assert result is False
 
+    @pytest.mark.asyncio
+    async def test_wait_for_pod_ready_uses_settings_default(self, pod_pool, pod_handle):
+        """When called with no explicit timeout, picks up the configured
+        settings.pod_pool_ready_timeout_seconds. Documents that the
+        previous 60s hardcoded default is gone — pools warming up large
+        images now have a configurable window.
+        """
+        mock_core_api = MagicMock()
+        mock_pod = MagicMock()
+        mock_pod.status.pod_ip = "10.0.0.1"
+        mock_pod.status.phase = "Running"
+        cs = MagicMock()
+        cs.name = "main"
+        cs.ready = True
+        mock_pod.status.container_statuses = [cs]
+        mock_core_api.read_namespaced_pod.return_value = mock_pod
+
+        with (
+            patch("src.services.kubernetes.pool.get_core_api", return_value=mock_core_api),
+            patch("src.config.settings") as mock_settings,
+        ):
+            mock_settings.pod_pool_ready_timeout_seconds = 7
+            # No explicit timeout — picks up settings.
+            result = await pod_pool._wait_for_pod_ready(pod_handle)
+        assert result is True
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "ImagePullBackOff",
+            "ErrImagePull",
+            "InvalidImageName",
+            "CrashLoopBackOff",
+            "CreateContainerConfigError",
+            "CreateContainerError",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_wait_for_pod_ready_early_aborts_on_terminal_waiting_reason(self, pod_pool, pod_handle, reason):
+        """Pods stuck in ImagePullBackOff / CrashLoopBackOff / etc. won't
+        ever become Ready. Early-abort so a misconfigured image fails in
+        a few seconds instead of after the full 300s timeout (and so the
+        operator sees the actual reason in logs, not a generic 'timeout').
+        """
+        mock_core_api = MagicMock()
+        mock_pod = MagicMock()
+        mock_pod.status.pod_ip = None
+        mock_pod.status.phase = "Pending"
+
+        cs = MagicMock()
+        cs.name = "main"
+        cs.ready = False
+        waiting = MagicMock()
+        waiting.reason = reason
+        waiting.message = "synthetic test message"
+        cs.state.waiting = waiting
+        mock_pod.status.container_statuses = [cs]
+        mock_core_api.read_namespaced_pod.return_value = mock_pod
+
+        with patch("src.services.kubernetes.pool.get_core_api", return_value=mock_core_api):
+            # Pass a long timeout — early-abort should fire well before
+            # we'd otherwise wait it out.
+            import time
+
+            start = time.monotonic()
+            result = await pod_pool._wait_for_pod_ready(pod_handle, timeout=30)
+            elapsed = time.monotonic() - start
+
+        assert result is False
+        assert elapsed < 5, f"early-abort took {elapsed:.2f}s; should be <5s on {reason}"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_pod_ready_waits_through_container_creating(self, pod_pool, pod_handle):
+        """ContainerCreating is NOT a terminal state — image is being
+        pulled and the pod will become Ready eventually. Don't early-abort.
+        """
+        mock_core_api = MagicMock()
+
+        # First two polls: still pulling. Third poll: ready.
+        pod_pulling = MagicMock()
+        pod_pulling.status.pod_ip = None
+        pod_pulling.status.phase = "Pending"
+        cs_pulling = MagicMock()
+        cs_pulling.name = "main"
+        cs_pulling.ready = False
+        waiting = MagicMock()
+        waiting.reason = "ContainerCreating"
+        cs_pulling.state.waiting = waiting
+        pod_pulling.status.container_statuses = [cs_pulling]
+
+        pod_ready = MagicMock()
+        pod_ready.status.pod_ip = "10.0.0.1"
+        pod_ready.status.phase = "Running"
+        cs_ready = MagicMock()
+        cs_ready.name = "main"
+        cs_ready.ready = True
+        pod_ready.status.container_statuses = [cs_ready]
+
+        mock_core_api.read_namespaced_pod.side_effect = [pod_pulling, pod_pulling, pod_ready]
+
+        with patch("src.services.kubernetes.pool.get_core_api", return_value=mock_core_api):
+            result = await pod_pool._wait_for_pod_ready(pod_handle, timeout=10)
+
+        assert result is True
+
 
 class TestPodPoolDeletePod:
     """Tests for _delete_pod method."""


### PR DESCRIPTION
## Summary

Two user-reported issues, fixed together because the second is what makes the first visible to users:

1. **\`ModuleNotFoundError: No module named 'xlsxwriter'\` (and reportlab / python-docx / python-pptx / pdf2image / ...) from \`bash_tool\`** — the bash image only had 5 apt-installed Python packages, so LC's \`python3 -c "..."\` reaches via bash_tool failed for anything beyond numpy/pandas/matplotlib/openpyxl/Pillow.
2. **\`POD_POOL_BASH=N doesn't actually wire through and change the number of warm replicas\`** — the Python config wiring is correct on paper; the runtime side had a 60s image-pull timeout that the now-1.13 GB bash image regularly exceeds on a cold node, so every newly-created warm pod got torn down before going Ready.

## Fix

### Part 1 — full python stack in the bash image

Install the FULL pip stack from the same \`docker/requirements/python-*.txt\` files the dedicated python image uses, so \`lang=py\` and \`lang=bash → python3 -c\` become indistinguishable.

Now in the bash image: \`xlsxwriter\`, \`reportlab\`, \`python-docx\`, \`python-pptx\`, \`pdf2image\`, \`docx2txt\`, \`docx2python\`, \`mammoth\`, \`openpyxl\`, \`scikit-learn\`, \`scipy\`, \`plotly\`, \`opencv-python-headless\`, \`pillow\`, \`numpy\`, \`pandas\`, \`matplotlib\`, \`seaborn\`, \`statsmodels\`, \`lxml\`, \`cryptography\`, \`pyarrow\`, \`sympy\`, and the rest.

Three DHI-base-specific problems had to be worked around to get this building against the live \`dhi.io/debian-base:trixie-debian13-dev\`:

| # | Problem | Workaround |
|---|---------|------------|
| 1 | \`r-base-core\` + \`gfortran\` transitively need \`liblapack3\` + \`libgfortran5\` pinned to stock \`gcc-14-base=14.2.0-19\`, but DHI ships \`14.2.0-19+dhi0\`. APT solver can't satisfy. | Removed both from the bash image. Dedicated \`lang=r\` / \`lang=f90\` per-language images still serve those callers; LC's bash_tool doesn't reach for them in practice. |
| 2 | DHI's hardened \`libzstd1+dhi0\` fails \`dlopen()\` (\`ImportError: libzstd.so.1: shared object cannot be dlopen()ed\`). Python's \`_ssl.so\` links libzstd → SSL completely broken → pip can't reach PyPI. | Force-downgrade to stock \`libzstd1=1.5.7+dfsg-1\` via \`--allow-downgrades\`. |
| 3 | Same \`dlopen\` issue on \`libffi8+dhi0\`. \`_ctypes.so\` links libffi → pandas/numpy/cryptography all crash at runtime. | Same fix: downgrade to \`libffi8=3.4.8-2\`. |

These three are pre-existing breakages of the bash image build against the current DHI registry — \`main\` was also unbuildable today.

### Part 2 — POD_POOL_<LANG> ready timeout

**Why warm replicas weren't materialising:** \`PodPool._wait_for_pod_ready\` hardcoded a 60s timeout. The unified bash image (~1.13 GB) regularly exceeds 60s on first pull. Every warm pod got torn down before going Ready, the pool stayed at 0, and the only log was a quiet \`warning="Warm pod did not become ready, deleting"\` with no indication WHY. Operators reading kubectl saw \`replicas: 0\` despite \`POD_POOL_BASH=N\` and nothing in our logs explained the gap.

Three changes:

1. **Configurable timeout** — new \`POD_POOL_READY_TIMEOUT_SECONDS\` setting, default **300s** (5 min), bounded [30, 1800]. Documented in \`.env.example\`.
2. **Early-abort on terminal pod states** — \`ImagePullBackOff\`, \`ErrImagePull\`, \`InvalidImageName\`, \`CrashLoopBackOff\`, \`CreateContainerConfigError\`, \`CreateContainerError\`. A misconfigured image now fails in ~5s with the actual reason logged at ERROR, instead of waiting out the full 300s.
3. **Loud diagnostic on real timeouts** — when we DO hit the timeout (typically a slow image pull stuck in ContainerCreating), log at ERROR with the last-observed waiting reason and a hint telling the operator whether to bump the timeout or investigate the cluster.

The companion rollup log in \`_create_warm_pod\` was bumped from WARNING to ERROR for the same operator-discoverability reason.

## Validation

- [x] Build succeeds against \`dhi.io/debian-base:trixie-debian13-dev\` (final image ~1.13 GB).
- [x] **User's exact failing reproduction now works**:
  \`\`\`python
  import xlsxwriter
  workbook = xlsxwriter.Workbook("/tmp/beispiel.xlsx")
  ws = workbook.add_worksheet()
  ws.write("A1", "Hallo")
  workbook.close()
  \`\`\`
  → xlsx written, 5,250 bytes.
- [x] Full \`docx + pptx + reportlab + pandas + numpy + matplotlib\` import chain works.
- [x] \`./scripts/test-bash-megaimage.sh\` — **11/11 languages pass** (bash, python, javascript, typescript, go, java, c, cpp, php, rust, d); r and fortran properly marked skipped.
- [x] **1,519 unit tests pass** (+8 new pool tests covering the timeout + early-abort cases).
- [x] \`just lint\` / \`just format-check\` / \`just typecheck\` — all clean.

## New tests

\`tests/unit/test_pool.py\`:
- \`test_wait_for_pod_ready_uses_settings_default\` — picks up \`settings.pod_pool_ready_timeout_seconds\` when called with no explicit timeout
- \`test_wait_for_pod_ready_early_aborts_on_terminal_waiting_reason[ImagePullBackOff/ErrImagePull/InvalidImageName/CrashLoopBackOff/CreateContainerConfigError/CreateContainerError]\` — 6 parametrized cases asserting the abort happens in <5s on a 30s nominal timeout
- \`test_wait_for_pod_ready_waits_through_container_creating\` — pins that \`ContainerCreating\` is NOT terminal (the image is being pulled; the wait must continue)

## Operator note

If you currently see \`POD_POOL_BASH=N\` not materialising warm replicas, this PR should fix it. If the new 300s default is still too short for your registry/node combo, bump \`POD_POOL_READY_TIMEOUT_SECONDS\` further. The new error logs will tell you which case you're in:
- \`last_waiting_reason=ContainerCreating\` → image pull is slow, raise the timeout
- \`last_waiting_reason=ImagePullBackOff\` → genuine image config error (wrong registry, bad tag, missing pull secret) — early-abort will catch this
- \`last_waiting_reason=None\` after Running → runner /ready probe wedged inside the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)