### PR TITLE
fix: add missing `/sessions/{session_id}/objects/{file_id}` endpoint for LibreChat file freshness check

### DIFF
--- a/src/api/files.py
+++ b/src/api/files.py
@@ -572,6 +572,75 @@ async def download_file_options(session_id: str, file_id: str):
     )
 
 
+@router.get("/sessions/{session_id}/objects/{file_id}")
+async def get_session_object(
+    session_id: str,
+    file_id: str,
+    kind: str | None = Query(None, description="Resource kind: 'skill', 'agent', or 'user'"),
+    id: str | None = Query(None, description="Resource id (userId / agentId / skillId)"),
+    version: int | None = Query(None, description="Resource version (only meaningful for kind=skill)"),
+    file_service: FileServiceDep = None,
+    session_service: SessionServiceDep = None,
+):
+    """Return file object metadata for a session - LibreChat compatible.
+
+    Called by LibreChat's ``getSessionInfo`` (process.js) to check whether a
+    previously-uploaded file is still live in the code environment.  The
+    response must include ``lastModified`` — LibreChat uses it to decide
+    whether to re-upload.
+
+    Query params ``kind``/``id``/``version`` are accepted for parity with
+    LibreChat's ``buildCodeEnvDownloadQuery`` but are not enforced today.
+    """
+    try:
+        file_info = await file_service.get_file_info(session_id, file_id)
+        if not file_info:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        # Determine lastModified: prefer session last_activity for active
+        # sessions (mirrors the /files/{session_id} detail=summary logic).
+        last_modified = None
+        try:
+            session = await session_service.get_session(session_id)
+            if session:
+                if session.status == SessionStatus.ACTIVE:
+                    last_modified = datetime.now(UTC)
+                elif session.last_activity:
+                    act = session.last_activity
+                    if isinstance(act, str):
+                        act = datetime.fromisoformat(act)
+                    if act.tzinfo is None:
+                        act = act.replace(tzinfo=UTC)
+                    last_modified = act
+        except Exception:
+            pass
+
+        if last_modified is None:
+            last_modified = file_info.created_at
+            if isinstance(last_modified, str):
+                last_modified = datetime.fromisoformat(last_modified)
+            if last_modified.tzinfo is None:
+                last_modified = last_modified.replace(tzinfo=UTC)
+
+        last_modified_str = last_modified.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+        return {
+            "name": f"{session_id}/{file_id}",
+            "lastModified": last_modified_str,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Failed to get session object info",
+            session_id=session_id,
+            file_id=file_id,
+            error=str(e),
+        )
+        raise HTTPException(status_code=404, detail="File not found")
+
+
 @router.delete("/files/{session_id}/{file_id}")
 async def delete_file(session_id: str, file_id: str, file_service: FileServiceDep = None):
     """Delete a file from the session - LibreChat compatible."""

--- a/src/api/files.py
+++ b/src/api/files.py
@@ -577,7 +577,7 @@ async def get_session_object(
     session_id: str,
     file_id: str,
     kind: str | None = Query(None, description="Resource kind: 'skill', 'agent', or 'user'"),
-    id: str | None = Query(None, description="Resource id (userId / agentId / skillId)"),
+    resource_id: str | None = Query(None, alias="id", description="Resource id (userId / agentId / skillId)"),
     version: int | None = Query(None, description="Resource version (only meaningful for kind=skill)"),
     file_service: FileServiceDep = None,
     session_service: SessionServiceDep = None,
@@ -612,8 +612,12 @@ async def get_session_object(
                     if act.tzinfo is None:
                         act = act.replace(tzinfo=UTC)
                     last_modified = act
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve session for lastModified derivation, falling back to file created_at",
+                session_id=session_id,
+                error=str(exc),
+            )
 
         if last_modified is None:
             last_modified = file_info.created_at
@@ -638,7 +642,7 @@ async def get_session_object(
             file_id=file_id,
             error=str(e),
         )
-        raise HTTPException(status_code=404, detail="File not found")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.delete("/files/{session_id}/{file_id}")

--- a/tests/unit/test_librechat_contract.py
+++ b/tests/unit/test_librechat_contract.py
@@ -379,7 +379,7 @@ class TestGetSessionObject:
             session_id="sess-1",
             file_id="file-abc",
             kind="user",
-            id="user-123",
+            resource_id="user-123",
             version=None,
             file_service=file_service,
             session_service=session_service,
@@ -387,8 +387,10 @@ class TestGetSessionObject:
 
         assert "lastModified" in result
         assert result["name"] == "sess-1/file-abc"
-        # Active session should yield a recent timestamp (not None)
+        # Active session should yield a timestamp close to now (not file's created_at)
         assert result["lastModified"].endswith("Z")
+        parsed = datetime.fromisoformat(result["lastModified"].replace("Z", "+00:00"))
+        assert abs((datetime.now(UTC) - parsed).total_seconds()) < 5
 
     @pytest.mark.asyncio
     async def test_returns_404_when_file_not_found(self):
@@ -403,7 +405,7 @@ class TestGetSessionObject:
                 session_id="sess-1",
                 file_id="nonexistent",
                 kind="user",
-                id="user-123",
+                resource_id="user-123",
                 version=None,
                 file_service=file_service,
                 session_service=session_service,
@@ -434,10 +436,48 @@ class TestGetSessionObject:
             session_id="s1",
             file_id="fid",
             kind="skill",
-            id="skill-42",
+            resource_id="skill-42",
             version=3,
             file_service=file_service,
             session_service=session_service,
         )
 
         assert "lastModified" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_last_activity_for_inactive_session(self):
+        """Inactive session with last_activity should use that timestamp."""
+        from datetime import UTC, datetime
+
+        from src.models.files import FileInfo
+        from src.models.session import Session, SessionStatus
+
+        file_info = FileInfo(
+            file_id="file-abc",
+            filename="data.csv",
+            size=42,
+            content_type="text/csv",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            path="/data.csv",
+        )
+        file_service = MagicMock()
+        file_service.get_file_info = AsyncMock(return_value=file_info)
+
+        session = MagicMock()
+        session.status = SessionStatus.TERMINATED
+        session.last_activity = datetime(2026, 3, 15, 10, 30, 0, tzinfo=UTC)
+
+        session_service = MagicMock()
+        session_service.get_session = AsyncMock(return_value=session)
+
+        result = await get_session_object(
+            session_id="sess-1",
+            file_id="file-abc",
+            kind="user",
+            resource_id="user-123",
+            version=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert result["lastModified"] == "2026-03-15T10:30:00.000Z"

--- a/tests/unit/test_librechat_contract.py
+++ b/tests/unit/test_librechat_contract.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.api.files import list_files, upload_file, upload_files_batch
+from src.api.files import get_session_object, list_files, upload_file, upload_files_batch
 from src.models.exec import FileRef, RequestFile
 
 # ---------------------------------------------------------------------------
@@ -340,3 +340,104 @@ class TestListFilesContract:
         assert len(result) == 1
         assert result[0]["storage_session_id"] == "sess-1"
         assert result[0]["session_id"] == "sess-1"
+
+
+class TestGetSessionObject:
+    """Tests for GET /sessions/{session_id}/objects/{file_id}.
+
+    LibreChat's ``getSessionInfo`` (process.js) calls this endpoint to check
+    whether a previously-uploaded file is still active.  It expects a JSON
+    response with ``lastModified``.  A 404 triggers a re-upload cycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_last_modified_for_existing_file(self):
+        from datetime import UTC, datetime
+
+        from src.models.files import FileInfo
+        from src.models.session import Session, SessionStatus
+
+        file_info = FileInfo(
+            file_id="file-abc",
+            filename="data.csv",
+            size=42,
+            content_type="text/csv",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            path="/data.csv",
+        )
+        file_service = MagicMock()
+        file_service.get_file_info = AsyncMock(return_value=file_info)
+
+        session = MagicMock()
+        session.status = SessionStatus.ACTIVE
+        session.last_activity = datetime(2026, 1, 2, tzinfo=UTC)
+
+        session_service = MagicMock()
+        session_service.get_session = AsyncMock(return_value=session)
+
+        result = await get_session_object(
+            session_id="sess-1",
+            file_id="file-abc",
+            kind="user",
+            id="user-123",
+            version=None,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert "lastModified" in result
+        assert result["name"] == "sess-1/file-abc"
+        # Active session should yield a recent timestamp (not None)
+        assert result["lastModified"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_file_not_found(self):
+        from fastapi import HTTPException
+
+        file_service = MagicMock()
+        file_service.get_file_info = AsyncMock(return_value=None)
+        session_service = MagicMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await get_session_object(
+                session_id="sess-1",
+                file_id="nonexistent",
+                kind="user",
+                id="user-123",
+                version=None,
+                file_service=file_service,
+                session_service=session_service,
+            )
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_accepts_kind_id_version_params_without_error(self):
+        """The kind/id/version query params must be accepted (no 422)."""
+        from datetime import UTC, datetime
+
+        from src.models.files import FileInfo
+
+        file_info = FileInfo(
+            file_id="fid",
+            filename="script.py",
+            size=10,
+            content_type="text/x-python",
+            created_at=datetime(2026, 5, 1, tzinfo=UTC),
+            path="/script.py",
+        )
+        file_service = MagicMock()
+        file_service.get_file_info = AsyncMock(return_value=file_info)
+        session_service = MagicMock()
+        session_service.get_session = AsyncMock(return_value=None)
+
+        result = await get_session_object(
+            session_id="s1",
+            file_id="fid",
+            kind="skill",
+            id="skill-42",
+            version=3,
+            file_service=file_service,
+            session_service=session_service,
+        )
+
+        assert "lastModified" in result


### PR DESCRIPTION
## Problem

LibreChat's `getSessionInfo` (in `process.js`) calls `GET /sessions/{session_id}/objects/{file_id}?kind=user&id={userId}` to verify whether previously-uploaded files are still active in the code environment before priming them into the sandbox.

KubeCodeRun lacked this route entirely, so every call returned **404**. This caused LibreChat to treat every file as expired, triggering a re-upload cycle on every turn. Users experienced repeated "you haven't uploaded any file" errors and had to retry messages multiple times until the session state aligned.

## Fix

Added `GET /sessions/{session_id}/objects/{file_id}` endpoint that returns `{ name, lastModified }`, satisfying LibreChat's freshness check. The endpoint:

- Looks up the file in the session's storage (Redis metadata)
- Returns the session's `last_activity` timestamp for active sessions (matching the existing `/files/{session_id}` summary logic)
- Accepts `kind`, `id`, `version` query params for LibreChat compatibility (not enforced server-side)
- Returns 404 only when the file genuinely doesn't exist

## Evidence (LibreChat calling this endpoint)

LibreChat's `getSessionInfo()` in [`api/server/services/Files/Code/process.js:681`](https://github.com/nosportugal/librechat) builds:

```js
url: `${baseURL}/sessions/${ref.storage_session_id}/objects/${ref.file_id}${query}`
// query = buildCodeEnvDownloadQuery({ kind, id, version? })
// e.g. ?kind=user&id=677feb476a21a09984bc4b04
```

This is invoked from two call sites:
1. **`primeCodeFiles`** (process.js:933) — checks freshness of every previously-uploaded file before each code execution turn.
2. **`primeSkillFiles`** (packages/api/src/agents/skillFiles.ts:118) — checks freshness of skill-primed files.

If the endpoint returns 404 (missing), `getSessionInfo` returns `null`, LibreChat treats the file as expired, and attempts a re-upload cycle. With KubeCodeRun lacking this route, **every turn** triggered this cycle, explaining the repeated "you haven't uploaded any file" error and the flood of 404s in logs.

The `checkIfActive()` function (process.js:661) checks that `lastModified` is less than 23 hours old. For active sessions, we return `datetime.now(UTC)` which always satisfies this constraint.